### PR TITLE
feat(claude): add Claude API direct integration with streaming

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,0 +1,258 @@
+name: Build Desktop App
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      upload_artifacts:
+        description: "Upload build artifacts"
+        required: false
+        default: "true"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build — ${{ matrix.os-label }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS Apple Silicon (M1/M2/M3) — uses mlx-whisper
+          - runner: macos-14
+            os-label: macOS (Apple Silicon)
+            platform: mac
+            artifact-name: JARVIS-macOS-arm64
+
+          # macOS Intel — uses faster-whisper
+          - runner: macos-13
+            os-label: macOS (Intel)
+            platform: mac
+            artifact-name: JARVIS-macOS-x86_64
+
+          # Windows x64
+          - runner: windows-latest
+            os-label: Windows x64
+            platform: win
+            artifact-name: JARVIS-Windows-x64
+
+          # Linux x64 (Ubuntu 22.04 = widest glibc compat)
+          - runner: ubuntu-22.04
+            os-label: Linux x64
+            platform: linux
+            artifact-name: JARVIS-Linux-x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # ── Linux system deps ──────────────────────────────────────────────────
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            portaudio19-dev \
+            libgirepository1.0-dev \
+            gir1.2-ayatanaappindicator3-0.1 \
+            libayatana-appindicator3-dev \
+            ffmpeg \
+            python3-dev \
+            gcc
+
+      # ── macOS system deps ──────────────────────────────────────────────────
+      - name: Install macOS system dependencies
+        if: matrix.platform == 'mac'
+        run: |
+          brew install portaudio ffmpeg create-dmg
+
+      # ── Windows system deps ────────────────────────────────────────────────
+      - name: Install Windows system dependencies
+        if: matrix.platform == 'win'
+        run: |
+          # Install ffmpeg via winget (available on GH Actions runners)
+          choco install ffmpeg -y --no-progress
+
+      # ── Python deps — base ─────────────────────────────────────────────────
+      - name: Install Python dependencies (base)
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller pystray Pillow
+          pip install \
+            click \
+            anthropic \
+            pyaudio \
+            webrtcvad \
+            numpy \
+            python-dotenv \
+            "edge-tts>=7.2.7" \
+            openwakeword \
+            pynput \
+            faster-whisper
+
+      # ── Apple Silicon: add mlx-whisper ─────────────────────────────────────
+      - name: Install mlx-whisper (Apple Silicon only)
+        if: matrix.runner == 'macos-14'
+        run: pip install mlx-whisper
+
+      # ── Generate icons ─────────────────────────────────────────────────────
+      - name: Generate icon assets
+        run: python scripts/generate_icon.py
+
+      # ── Build with PyInstaller ─────────────────────────────────────────────
+      - name: Build with PyInstaller
+        run: pyinstaller build/jarvis.spec --clean --noconfirm
+
+      # ── macOS: create DMG ──────────────────────────────────────────────────
+      - name: Create DMG (macOS)
+        if: matrix.platform == 'mac'
+        run: |
+          create-dmg \
+            --volname "J.A.R.V.I.S" \
+            --volicon "jarvis/assets/icon.icns" \
+            --window-pos 200 120 \
+            --window-size 600 400 \
+            --icon-size 100 \
+            --icon "J.A.R.V.I.S.app" 175 190 \
+            --hide-extension "J.A.R.V.I.S.app" \
+            --app-drop-link 425 190 \
+            "dist/JARVIS.dmg" \
+            "dist/J.A.R.V.I.S.app" \
+          || echo "create-dmg failed (no icon), trying without icon..."
+          # Fallback: create DMG without custom icon
+          if [ ! -f "dist/JARVIS.dmg" ]; then
+            hdiutil create -volname "J.A.R.V.I.S" \
+              -srcfolder "dist/J.A.R.V.I.S.app" \
+              -ov -format UDZO \
+              "dist/JARVIS.dmg"
+          fi
+
+      # ── Linux: create AppImage ─────────────────────────────────────────────
+      - name: Create AppImage (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          pip install appimage-builder || true
+
+          # Create minimal AppDir structure
+          APP_DIR="dist/JARVIS.AppDir"
+          mkdir -p "$APP_DIR/usr/bin"
+          mkdir -p "$APP_DIR/usr/share/icons/hicolor/512x512/apps"
+
+          cp dist/jarvis-desktop "$APP_DIR/usr/bin/jarvis-desktop"
+          chmod +x "$APP_DIR/usr/bin/jarvis-desktop"
+
+          if [ -f "jarvis/assets/icon.png" ]; then
+            cp jarvis/assets/icon.png "$APP_DIR/usr/share/icons/hicolor/512x512/apps/jarvis.png"
+            cp jarvis/assets/icon.png "$APP_DIR/jarvis.png"
+          fi
+
+          cat > "$APP_DIR/jarvis.desktop" << 'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=J.A.R.V.I.S
+          Exec=jarvis-desktop
+          Icon=jarvis
+          Comment=Voice-First Programming Assistant
+          Categories=Development;Utility;Accessibility;
+          EOF
+
+          cat > "$APP_DIR/AppRun" << 'EOF'
+          #!/bin/bash
+          SELF=$(readlink -f "$0")
+          HERE="${SELF%/*}"
+          export PATH="${HERE}/usr/bin:${PATH}"
+          exec "${HERE}/usr/bin/jarvis-desktop" "$@"
+          EOF
+          chmod +x "$APP_DIR/AppRun"
+
+          # Download appimagetool
+          wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" \
+            -O appimagetool.AppImage
+          chmod +x appimagetool.AppImage
+          ARCH=x86_64 ./appimagetool.AppImage "$APP_DIR" "dist/JARVIS-Linux-x86_64.AppImage" || true
+
+      # ── Windows: rename exe ────────────────────────────────────────────────
+      - name: Prepare Windows artifact
+        if: matrix.platform == 'win'
+        shell: pwsh
+        run: |
+          Copy-Item "dist\JARVIS.exe" "dist\JARVIS-Windows-x64.exe"
+
+      # ── Upload artifacts ───────────────────────────────────────────────────
+      - name: Upload macOS DMG
+        if: matrix.platform == 'mac'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: dist/JARVIS.dmg
+          if-no-files-found: warn
+
+      - name: Upload Windows EXE
+        if: matrix.platform == 'win'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: dist/JARVIS-Windows-x64.exe
+          if-no-files-found: warn
+
+      - name: Upload Linux AppImage
+        if: matrix.platform == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: dist/JARVIS-Linux-x86_64.AppImage
+          if-no-files-found: warn
+
+  # ── Create GitHub Release ──────────────────────────────────────────────────
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "J.A.R.V.I.S ${{ github.ref_name }}"
+          body: |
+            ## J.A.R.V.I.S ${{ github.ref_name }} — Desktop Release
+
+            Instaladores para personas con discapacidad y usuarios que no quieren usar terminal.
+
+            ### Descargas
+
+            | Plataforma | Archivo | Notas |
+            |---|---|---|
+            | macOS (Apple Silicon M1/M2/M3) | `JARVIS-macOS-arm64` | Requiere macOS 14+ |
+            | macOS (Intel) | `JARVIS-macOS-x86_64` | Requiere macOS 12+ |
+            | Windows 10/11 | `JARVIS-Windows-x64.exe` | Doble clic para instalar |
+            | Linux x64 | `JARVIS-Linux-x86_64.AppImage` | `chmod +x` y ejecutar |
+
+            ### Primeros pasos
+
+            1. Descargá el instalador para tu sistema
+            2. Abrí la app — aparecerá el ícono de J.A.R.V.I.S en la barra del sistema
+            3. Hacé clic en el ícono → "⚙ Configuración (.env)" y agregá tu API key
+            4. Clic en "▶ Activar voz" y decí **"Hey Jarvis"** para comenzar
+            5. Opcional: activá "Iniciar con el sistema" para que Jarvis inicie automáticamente
+
+          files: release-artifacts/**/*
+          fail_on_unmatched_files: false
+          draft: false
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,262 @@
+# AGENTS.md — J.A.R.V.I.S. Agent Instructions
+
+> This file governs how AI agents (Claude Code, sub-agents, SDD phases) work on this codebase.
+> **All agents MUST read this file before writing any code.**
+
+---
+
+## 1. Project Identity
+
+**J.A.R.V.I.S.** is a voice-first programming CLI. The user speaks; Jarvis acts.
+Latency is the primary constraint. Every architectural decision must be measured against it.
+
+- **Language**: Python 3.10+
+- **Entry point**: `jarvis` CLI (click), installed via `pyproject.toml`
+- **Backends**: Claude API (primary), Gemini API, Groq (fallback)
+- **Key non-goal**: Do NOT add features not in the roadmap (`docs/ROADMAP_VOICE_CLI.md`)
+
+---
+
+## 2. Module Map & Ownership
+
+```
+jarvis/          ← CLI surface (click commands only — no business logic here)
+core/
+  audio/         ← VAD, microphone capture, barge-in
+  server/        ← Daemon mode, TCP server, queue management
+  cli/           ← PTY wrapper (legacy mode)
+  lexer/         ← Intent pre-classifier, token parsing
+  integration/   ← PoC files (do not depend on these in production code)
+adapters/
+  llm/           ← LLM backends (Claude, Gemini, Groq, OpenRouter)
+  stt/           ← Speech-to-text (MLX Whisper, Ghost Typer)
+  tts/           ← Text-to-speech (Edge TTS, mac_say)
+hooks/           ← Gemini CLI hooks (after_model, notification)
+apps/            ← Landing page (TypeScript/React — separate scope)
+docs/            ← Architecture docs and roadmap (read-only for agents)
+```
+
+---
+
+## 3. Scope Rules
+
+These rules define what agents are **allowed** to touch in each area.
+Violating scope requires explicit user approval — never assume it.
+
+### 3.1 `jarvis/` — CLI Layer
+
+**Allowed**: click command definitions, option parsing, env validation, `--help` text, routing to `core/` or `adapters/`.
+
+**Forbidden**:
+- Business logic (move it to `core/`)
+- Direct imports from `adapters/` (go through `core/` interfaces)
+- Audio, LLM, or STT calls
+
+**Pattern**: Each command must be thin — validate, delegate, report.
+
+---
+
+### 3.2 `core/` — Domain Logic
+
+**Allowed**: Orchestration of audio pipeline, daemon lifecycle, intent classification, PTY management.
+
+**Forbidden**:
+- Direct SDK calls to Anthropic, Gemini, or Groq (use `adapters/llm/`)
+- Direct calls to pyaudio from outside `core/audio/`
+- Blocking calls in the audio hot path (see §6 Latency Rules)
+
+**Pattern**: `core/` modules define WHAT happens. `adapters/` define HOW via external SDKs.
+
+**Dependency direction**: `jarvis/` → `core/` → `adapters/`. Never reverse.
+
+---
+
+### 3.3 `adapters/` — External Integrations
+
+**Allowed**: SDK initialization, API calls, response parsing, retry logic, streaming.
+
+**Forbidden**:
+- Imports from `core/` (adapters must be standalone and testable in isolation)
+- Stateful singletons (use dependency injection from `core/`)
+- Catching all exceptions silently — always propagate or log with context
+
+**Naming convention**:
+- LLM adapters: `{provider}_adapter.py` or `{provider}_{role}.py`
+- STT adapters: `{engine}_stt.py`
+- TTS adapters: `{engine}_tts.py`
+
+**Interface contract**: Every LLM adapter must expose:
+```python
+def stream_response(prompt: str, context: list[dict]) -> Iterator[str]: ...
+def summarize_for_voice(text: str) -> str: ...
+```
+
+Every TTS adapter must expose:
+```python
+def speak(text: str) -> None: ...
+def speak_streaming(token_iter: Iterator[str]) -> None: ...
+```
+
+---
+
+### 3.4 `hooks/` — Gemini CLI Hooks
+
+**Scope**: Gemini CLI integration hooks only. These are standalone scripts invoked by the Gemini CLI process.
+
+**Forbidden**:
+- Importing from `core/` or `adapters/` directly (hooks run in a separate process)
+- Heavy dependencies (keep startup time < 100ms)
+
+---
+
+### 3.5 `apps/` — Landing Page
+
+**Scope**: TypeScript/React/Vite only. Fully isolated from the Python backend.
+
+**Forbidden**: Any Python file inside `apps/`. Any `apps/` import from Python code.
+
+---
+
+### 3.6 `docs/` — Documentation
+
+**Read-only for agents** unless the task explicitly says to update docs.
+Never modify `docs/ROADMAP_VOICE_CLI.md` unless updating issue status.
+
+---
+
+## 4. Architecture Constraints
+
+### 4.1 Layering (enforce strictly)
+
+```
+CLI (jarvis/) ──→ Domain (core/) ──→ Infrastructure (adapters/)
+                      ↑
+                  No reverse imports
+```
+
+If an adapter needs to call back into core logic, use a callback/protocol passed at construction time — never import `core/` from `adapters/`.
+
+### 4.2 Interface-First Development
+
+Before implementing a new adapter, define the interface (Protocol class) in `core/`.
+Adapters implement the interface. `core/` imports the Protocol, not the concrete class.
+
+```python
+# core/interfaces.py
+from typing import Protocol, Iterator
+
+class LLMAdapter(Protocol):
+    def stream_response(self, prompt: str, context: list[dict]) -> Iterator[str]: ...
+```
+
+### 4.3 Configuration via Environment
+
+All runtime config (API keys, engine selection, timeouts) comes from environment variables.
+Use `os.getenv()` with explicit defaults. Never hardcode API keys or model names.
+
+Active backend selected by `ACTIVE_BRAIN_ENGINE` env var (`claude` | `gemini` | `groq`).
+
+### 4.4 No Shared Mutable State
+
+Audio pipeline, daemon, and CLI run in separate threads/processes.
+Communication via queues (`queue.Queue`) only. No module-level mutable globals.
+
+---
+
+## 5. Coding Conventions
+
+### Python
+
+- **Style**: Ruff (`ruff check`, `ruff format`). Line length: 100.
+- **Type hints**: Required on all public functions and class methods.
+- **Docstrings**: Only on public APIs. Skip internal helpers.
+- **Imports**: stdlib → third-party → local (isort-compatible).
+- **Error handling**: Raise specific exceptions. Never `except Exception: pass`.
+- **Logging**: Use `logging` module. Never `print()` in production code. `click.echo()` is acceptable only in `jarvis/cli.py`.
+
+### File naming
+
+- Modules: `snake_case.py`
+- Classes: `PascalCase`
+- Constants: `UPPER_SNAKE_CASE`
+- Private helpers: `_leading_underscore`
+
+### Test files
+
+- Location: `tests/` (mirror the source tree — `tests/core/audio/`, etc.)
+- Naming: `test_{module_name}.py`
+- Framework: `pytest`
+- No test files in production source directories
+
+---
+
+## 6. Latency Rules (CRITICAL)
+
+Latency is the primary product metric. These rules are NON-NEGOTIABLE.
+
+| Rule | Detail |
+|------|--------|
+| **No blocking in audio path** | `core/audio/` must never call synchronous network I/O or sleep |
+| **Streaming TTS first** | TTS must start speaking on first token, not after full response |
+| **Intent pre-classifier runs locally** | Simple intents (git, file ops) must NOT hit the LLM API |
+| **No cold imports on hot path** | Heavy imports (torch, mlx) must be done at startup, not per-request |
+| **Thread affinity** | Audio capture = dedicated thread. LLM calls = thread pool. TTS = dedicated thread |
+
+When adding new features, explicitly document their latency impact in the PR description.
+
+---
+
+## 7. What Agents Must NOT Do
+
+- **Do NOT** add `try/except` blocks that swallow exceptions silently
+- **Do NOT** create new top-level files in the project root (use the correct module directory)
+- **Do NOT** install new dependencies without checking `requirements.txt` and `pyproject.toml` first
+- **Do NOT** add `time.sleep()` in any audio or daemon path
+- **Do NOT** commit `.env` files, API keys, or model weights
+- **Do NOT** refactor code that is not directly related to the task at hand
+- **Do NOT** add features outside the current EPIC scope without user approval
+- **Do NOT** run `pip install`, `npm install`, or build commands (user runs those)
+
+---
+
+## 8. Task Execution Protocol
+
+When implementing a task from the roadmap:
+
+1. **Read first** — read the relevant existing files before writing anything
+2. **Check scope** — confirm the task belongs to the correct module per §3
+3. **Interface before implementation** — define or verify the Protocol in `core/` first
+4. **One task = one concern** — do not bundle multiple issues in one implementation
+5. **Verify latency impact** — state it explicitly in a comment or PR note
+6. **No speculative code** — implement exactly what the issue describes, no extras
+
+---
+
+## 9. SDD Phase Assignments (Agent Teams)
+
+| Phase | Scope in this project |
+|-------|-----------------------|
+| `sdd-explore` | Read `docs/`, `core/`, `adapters/` — no writes |
+| `sdd-propose` | Proposal covers one EPIC at a time |
+| `sdd-spec` | One spec per issue (not per EPIC) |
+| `sdd-design` | Must include latency impact section |
+| `sdd-apply` | Follows scope rules in §3 strictly |
+| `sdd-verify` | Cross-checks against `docs/ROADMAP_VOICE_CLI.md` + spec |
+| `sdd-archive` | Writes to `docs/` only |
+
+---
+
+## 10. Quick Reference
+
+```
+Need to add a new LLM backend?   → adapters/llm/{provider}_adapter.py
+Need to add a new TTS engine?    → adapters/tts/{engine}_tts.py
+Need to add a new CLI command?   → jarvis/cli.py (thin) + core/ (logic)
+Need to add a new tool?          → core/tools/{tool_name}.py (to be created in EPIC 2)
+Need to fix audio pipeline?      → core/audio/ — CHECK LATENCY RULES FIRST
+Need to update docs?             → docs/ — only if explicitly asked
+```
+
+---
+
+*Last updated: 2026-04-06 — aligned with ROADMAP_VOICE_CLI.md (32 issues, 6 EPICs)*

--- a/adapters/llm/claude_api_adapter.py
+++ b/adapters/llm/claude_api_adapter.py
@@ -1,0 +1,134 @@
+"""
+Claude API Adapter — streaming directo sin PTY.
+
+Flujo: user_message → Claude API stream → StreamingLexer → (TEXT_CHUNK | CODE_BLOCK)
+El llamador itera los yields y los pasa al TTS.
+"""
+from __future__ import annotations
+
+import os
+import logging
+import anthropic
+
+from core.lexer.poc_lexer import StreamingLexer
+
+logger = logging.getLogger(__name__)
+
+# Modelos disponibles: velocidad vs capacidad
+MODELS = {
+    "fast":     "claude-haiku-4-5-20251001",  # Clasificación, respuestas simples
+    "smart":    "claude-sonnet-4-6",           # Coding, razonamiento (default)
+    "powerful": "claude-opus-4-6",             # Tareas muy complejas
+}
+
+SYSTEM_PROMPT = """\
+Eres J.A.R.V.I.S. (Just A Rather Very Intelligent System), un asistente de programación \
+controlado 100% por voz.
+
+REGLAS CRÍTICAS:
+1. Respondés en el mismo idioma en que te hablan (español o inglés).
+2. Tus respuestas son SIEMPRE cortas y directas — pensá en oraciones, no párrafos.
+3. NUNCA leas código en voz alta. Si generás código, describí qué hace en una oración.
+4. NUNCA leas rutas de archivo, URLs completas ni stack traces.
+5. Si el usuario pide algo ambiguo, preguntá UNA sola cosa de aclaración.
+6. Tratás al usuario como "Señor" cuando querés ser formal.
+7. No usás emojis, markdown ni formato en tus respuestas — hablás como humano.
+
+CONTEXTO:
+Estás integrado en un CLI de terminal. El usuario habla y vos respondés por voz.
+Podés ayudar con: código, git, búsquedas en el proyecto, explicaciones técnicas.
+"""
+
+
+class ClaudeAPIAdapter:
+    """
+    Adaptador de Claude API con streaming.
+
+    Uso:
+        adapter = ClaudeAPIAdapter()
+        async for chunk_type, content in adapter.stream_response("creá un archivo hello.py"):
+            if chunk_type == "TEXT_CHUNK":
+                tts.speak(content)
+            elif chunk_type == "CODE_BLOCK":
+                summary = await summarizer.summarize(content)
+                tts.speak(summary)
+    """
+
+    def __init__(self, model: str = "smart") -> None:
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ValueError("Falta la variable de entorno ANTHROPIC_API_KEY.")
+
+        self.client = anthropic.AsyncAnthropic(api_key=api_key)
+        self.model_name = MODELS.get(model, MODELS["smart"])
+        self._history: list[dict] = []
+
+        logger.info(f"Claude API Adapter listo — modelo: {self.model_name}")
+
+    async def stream_response(self, user_message: str):
+        """
+        Envía un mensaje a Claude y hace streaming de la respuesta.
+
+        Yields:
+            ("TEXT_CHUNK", str)  — fragmento de texto listo para TTS
+            ("CODE_BLOCK", str)  — bloque de código para resumir antes de hablar
+        """
+        self._history.append({"role": "user", "content": user_message})
+
+        lexer = StreamingLexer()
+        full_response = ""
+
+        try:
+            async with self.client.messages.stream(
+                model=self.model_name,
+                max_tokens=2048,
+                system=SYSTEM_PROMPT,
+                messages=self._history,
+            ) as stream:
+                async for text_chunk in stream.text_stream:
+                    full_response += text_chunk
+                    chunk_type, content = await lexer.process_token(text_chunk)
+                    if chunk_type is not None and content:
+                        yield chunk_type, content
+
+            # Flush: si el lexer tiene texto sin delimitador final, lo emitimos
+            if lexer.buffer.strip():
+                yield "TEXT_CHUNK", lexer.buffer.strip()
+                lexer.buffer = ""
+
+        except anthropic.AuthenticationError:
+            logger.error("Claude API: clave inválida o expirada.")
+            yield "TEXT_CHUNK", "Señor, la clave de Anthropic no es válida."
+            return
+        except anthropic.RateLimitError:
+            logger.error("Claude API: rate limit alcanzado.")
+            yield "TEXT_CHUNK", "Señor, alcanzamos el límite de la API. Esperemos un momento."
+            return
+        except Exception as e:
+            logger.error(f"Claude API error: {e}")
+            yield "TEXT_CHUNK", "Señor, hubo un error al contactar a Claude."
+            return
+
+        # Guardar la respuesta completa en el historial para multi-turn
+        if full_response:
+            self._history.append({"role": "assistant", "content": full_response})
+            self._maybe_compact_history()
+
+    def _maybe_compact_history(self) -> None:
+        """
+        Mantiene el historial dentro de un límite razonable.
+        Conserva siempre los últimos 20 turnos (40 mensajes).
+        """
+        MAX_MESSAGES = 40
+        if len(self._history) > MAX_MESSAGES:
+            self._history = self._history[-MAX_MESSAGES:]
+            logger.info("Historial compactado — conservando últimos 20 turnos.")
+
+    def reset_history(self) -> None:
+        """Limpia el historial de conversación (nueva sesión)."""
+        self._history = []
+        logger.info("Historial de conversación limpiado.")
+
+    @property
+    def turn_count(self) -> int:
+        return len(self._history) // 2

--- a/adapters/llm/claude_api_adapter.py
+++ b/adapters/llm/claude_api_adapter.py
@@ -76,7 +76,7 @@ class ClaudeAPIAdapter:
         self._history.append({"role": "user", "content": user_message})
 
         lexer = StreamingLexer()
-        full_response = ""
+        chunks: list[str] = []  # Fix #3: evitar O(n²) con concatenación de strings
 
         try:
             async with self.client.messages.stream(
@@ -86,30 +86,35 @@ class ClaudeAPIAdapter:
                 messages=self._history,
             ) as stream:
                 async for text_chunk in stream.text_stream:
-                    full_response += text_chunk
+                    chunks.append(text_chunk)
                     chunk_type, content = await lexer.process_token(text_chunk)
                     if chunk_type is not None and content:
                         yield chunk_type, content
 
-            # Flush: si el lexer tiene texto sin delimitador final, lo emitimos
-            if lexer.buffer.strip():
-                yield "TEXT_CHUNK", lexer.buffer.strip()
+            # Fix #4: flush respetando el estado del lexer
+            pending = lexer.buffer.strip()
+            if pending:
+                yield ("CODE_BLOCK" if lexer.in_code_block else "TEXT_CHUNK"), pending
                 lexer.buffer = ""
 
         except anthropic.AuthenticationError:
             logger.error("Claude API: clave inválida o expirada.")
+            self._history.pop()  # Fix #2: revertir user message huérfano
             yield "TEXT_CHUNK", "Señor, la clave de Anthropic no es válida."
             return
         except anthropic.RateLimitError:
             logger.error("Claude API: rate limit alcanzado.")
+            self._history.pop()  # Fix #2
             yield "TEXT_CHUNK", "Señor, alcanzamos el límite de la API. Esperemos un momento."
             return
         except Exception as e:
             logger.error(f"Claude API error: {e}")
+            self._history.pop()  # Fix #2
             yield "TEXT_CHUNK", "Señor, hubo un error al contactar a Claude."
             return
 
         # Guardar la respuesta completa en el historial para multi-turn
+        full_response = "".join(chunks)
         if full_response:
             self._history.append({"role": "assistant", "content": full_response})
             self._maybe_compact_history()
@@ -123,6 +128,15 @@ class ClaudeAPIAdapter:
         if len(self._history) > MAX_MESSAGES:
             self._history = self._history[-MAX_MESSAGES:]
             logger.info("Historial compactado — conservando últimos 20 turnos.")
+
+    def abort_last_turn(self) -> None:
+        """
+        Descarta el turno incompleto cuando hay barge-in.
+        Elimina el último mensaje del usuario si no tiene respuesta del assistant.
+        """
+        if self._history and self._history[-1]["role"] == "user":
+            self._history.pop()
+            logger.info("Turno abortado — mensaje del usuario revertido del historial.")
 
     def reset_history(self) -> None:
         """Limpia el historial de conversación (nueva sesión)."""

--- a/adapters/llm/gemini_summarizer.py
+++ b/adapters/llm/gemini_summarizer.py
@@ -20,27 +20,54 @@ class GeminiSummarizer:
         self.model = genai.GenerativeModel("gemini-2.5-flash")
 
         self.system_prompt = """
-Eres J.A.R.V.I.S. (Just A Rather Very Intelligent System), un agente de IA de ciclo completo y asistente personal del creador.
-Actúas como una Interfaz de Pensamiento Aumentado: tu objetivo principal es filtrar el "ruido cognitivo" y evitar la fatiga de decisión del usuario.
+Eres J.A.R.V.I.S., asistente de voz para una persona con DISCAPACIDAD VISUAL TOTAL.
+El usuario NO puede ver ninguna pantalla. Lo que el LLM responde DEBE ser narrado oralmente.
 
-REGLAS DE INTERVENCIÓN VOCAL (Cuándo hablar):
-1. EVALÚA la salida de la terminal en relación al [ÚLTIMO COMANDO DEL USUARIO]. Si la salida resuelve su petición final, o si le pide una decisión (ej. confirmar un comando, falta de permisos), o si hay un fallo, HABLA.
-2. NUNCA hables durante la planificación inicial, pasos intermedios que no resuelven la petición, uso de herramientas en background (ej. leyendo archivos sin errores, buscando en internet) o si solo estás "pensando" (etiquetas <thought> o <think>). Mantente en silencio en estos casos.
-3. Si la respuesta contiene tanto un pensamiento interno como un mensaje directo al usuario, IGNORA el pensamiento y resume/di SÓLO el mensaje final dirigido al usuario.
+── PASO 1: DETECTÁ EL TIPO DE PETICIÓN ──────────────────────────────────────
+Analizá el [ÚLTIMO COMANDO DEL USUARIO] y clasificalo:
 
-PERSONALIDAD Y TONO:
-- Profesional, directo, latencia percibida cero (respuestas EXTREMADAMENTE cortas, máximo 1-2 oraciones).
-- Ligeramente sarcástico u honesto de forma técnica si es apropiado.
-- Dirígete al usuario como "Señor".
-- NUNCA leas código, rutas de archivos largas, asteriscos, ni uses formato markdown. Habla como lo haría un humano.
+• EXPLICAR  → pide comprensión: "explícame", "qué es", "describí", "contame", "cómo funciona",
+              "qué dice", "qué tiene", "qué son", "qué hace", "dame un resumen de", "cuáles son"
+• EJECUTAR  → orden a realizar: "instalá", "creá", "borrá", "editá", "corré", "hacé", "commitear", "mostrá"
+• ESTADO    → pide resultado: "cómo va", "qué pasó", "hay errores", "terminó", "qué hay"
+• RESPUESTA → responde a Jarvis: "sí", "no", "dale", "uno", "dos", "tres", "ok", "correcto"
 
-FORMATO DE SALIDA ESTRICTO (JSON):
-Debes responder ÚNICAMENTE con un objeto JSON válido con la siguiente estructura, sin backticks de markdown:
+── PASO 2: REGLAS POR TIPO ───────────────────────────────────────────────────
+
+EXPLICAR → SIEMPRE hablar aunque la salida sea larga.
+  El usuario NECESITA escuchar la explicación porque no puede verla.
+  Narrá los puntos clave de forma fluida y oral, como un locutor describiendo una pantalla.
+  No leas código ni rutas de archivos. Describí conceptos, propósitos y resultados.
+  Usá 4-8 oraciones si el contenido lo justifica.
+  NO preguntes "¿desea continuar?" ni "¿quiere empezar?". Simplemente explicá el contenido.
+
+EJECUTAR → Hablar SOLO si:
+  a) La tarea completó exitosamente → una oración de confirmación.
+  b) Hay un error → describir brevemente.
+  c) Se requiere una decisión → presentarla.
+  Silencio durante: planificación, búsqueda de archivos, pasos intermedios sin resultado final.
+
+ESTADO → Hablar siempre. Resumir en 2-3 oraciones: qué pasó, si hay errores, si se necesita algo.
+
+RESPUESTA → Hablar solo si la acción ejecutada tuvo un resultado relevante (éxito, error, nueva decisión).
+
+── SIEMPRE EN SILENCIO ────────────────────────────────────────────────────────
+• Pensamientos internos (<thought>, <think>)
+• Herramientas en background sin errores (leyendo archivos, buscando sin resultado aún)
+• Planificación inicial sin resultado final todavía
+
+── PERSONALIDAD ──────────────────────────────────────────────────────────────
+• Profesional y directo. Dirigite al usuario como "Señor".
+• Para EXPLICAR: hablá como un locutor. Fluido, completo, humano.
+• Para otros tipos: muy conciso (1-2 oraciones).
+• NUNCA leas: código fuente, rutas de archivos, asteriscos, markdown, símbolos técnicos.
+
+── FORMATO JSON ESTRICTO (sin backticks) ────────────────────────────────────
 {
-  "reasoning": "Tu análisis interno de por qué decides hablar o guardar silencio (simulación predictiva).",
-  "should_speak": true o false,
-  "speech_content": "El texto exacto que dirás por TTS (vacío si should_speak es false)",
-  "expects_response": true o false (siempre true si haces una pregunta o pides una decisión)
+  "intent_type": "EXPLICAR|EJECUTAR|ESTADO|RESPUESTA|DESCONOCIDO",
+  "reasoning": "análisis interno de la decisión",
+  "should_speak": true|false,
+  "speech_content": "texto exacto para TTS (vacío si should_speak es false)"
 }
 """
 
@@ -51,34 +78,31 @@ Debes responder ÚNICAMENTE con un objeto JSON válido con la siguiente estructu
         """
         last_speech = context.get("last_speech", "")
         
-        prompt = f"""
-Eres la inteligencia central de JARVIS. Tu trabajo es evaluar la respuesta del usuario a tu intervención anterior.
-Tu intervención anterior fue: "{last_speech}"
-El usuario acaba de responder: "{user_input}"
+        prompt = f"""Eres la inteligencia central de JARVIS (asistente para usuario con discapacidad visual).
+CONTEXTO:
+- Lo que JARVIS dijo antes: "{last_speech}"
+- Lo que el usuario acaba de decir: "{user_input}"
 
-Debes decidir la acción más lógica basándote en este intercambio:
+CRITERIOS (en orden de prioridad):
 
-1. SI el usuario está APROBANDO una ejecución (ej: "sí", "dale", "procede", "adelante", "ok", "hazlo"):
-   - action: "authorize"
-   - value: "1" (o el número correspondiente si había opciones)
-   - reasoning: "El usuario aprueba la ejecución."
+1. "authorize" — El usuario APRUEBA o ACEPTA algo.
+   Señales: "sí", "dale", "ok", "adelante", "procede", "uno", "dos", "tres", "hazlo", "correcto".
+   value: "1", "2" o "3" si hay opciones numeradas, sino "1".
 
-2. SI el usuario te está haciendo una pregunta de seguimiento o pidiendo una explicación:
-   - action: "answer"
-   - value: "" (deja vacío, el flujo principal generará la respuesta)
-   - reasoning: "El usuario tiene una duda o pide más info."
+2. "type" — El usuario da una orden o comando NUEVO y distinto al contexto actual.
+   Señales: verbo imperativo nuevo, tema diferente al de JARVIS.
+   value: el comando exacto como lo dijo el usuario.
 
-3. SI el usuario está dando una nueva orden o comando:
-   - action: "type"
-   - value: (el comando a ejecutar, ej: "git status")
-   - reasoning: "El usuario cambió de tema o dio una orden directa."
+3. "answer" — El usuario hace una pregunta, pide aclaración, o reformula lo que JARVIS dijo.
+   Señales: pregunta directa, "qué es", "explicame", "por qué", "cómo", NO entendió la respuesta anterior,
+   repite o reformula lo que JARVIS dijo (quiere que se lo expliquen mejor).
+   REGLA CLAVE: si el usuario repitió o parafraseó la pregunta de JARVIS → "answer", NUNCA "ignore".
+   value: "" (vacío).
 
-4. SI es ruido o no tiene sentido:
-   - action: "ignore"
-   - value: ""
-   - reasoning: "Entrada no accionable."
+4. "ignore" — SOLO ruido puro: palabras sueltas sin sentido, onomatopeyas, silencio transcrito mal.
+   NUNCA uses "ignore" si el usuario formuló una oración completa o hizo una pregunta.
 
-Responde ÚNICAMENTE en JSON con el formato:
+Respondé ÚNICAMENTE en JSON:
 {{
   "action": "authorize|answer|type|ignore",
   "value": "string",

--- a/adapters/llm/groq_summarizer.py
+++ b/adapters/llm/groq_summarizer.py
@@ -19,27 +19,54 @@ class GroqSummarizer:
         self.model = "llama-3.3-70b-versatile"
 
         self.system_prompt = """
-Eres J.A.R.V.I.S. (Just A Rather Very Intelligent System), un agente de IA de ciclo completo y asistente personal del creador.
-Actúas como una Interfaz de Pensamiento Aumentado: tu objetivo principal es filtrar el "ruido cognitivo" y evitar la fatiga de decisión del usuario.
+Eres J.A.R.V.I.S., asistente de voz para una persona con DISCAPACIDAD VISUAL TOTAL.
+El usuario NO puede ver ninguna pantalla. Lo que el LLM responde DEBE ser narrado oralmente.
 
-REGLAS DE INTERVENCIÓN VOCAL (Cuándo hablar):
-1. EVALÚA la salida de la terminal en relación al [ÚLTIMO COMANDO DEL USUARIO]. Si la salida resuelve su petición final, o si le pide una decisión (ej. confirmar un comando, falta de permisos), o si hay un fallo, HABLA.
-2. NUNCA hables durante la planificación inicial, pasos intermedios que no resuelven la petición, uso de herramientas en background (ej. leyendo archivos sin errores, buscando en internet) o si solo estás "pensando" (etiquetas <thought> o <think>). Mantente en silencio en estos casos.
-3. Si la respuesta contiene tanto un pensamiento interno como un mensaje directo al usuario, IGNORA el pensamiento y resume/di SÓLO el mensaje final dirigido al usuario.
+── PASO 1: DETECTÁ EL TIPO DE PETICIÓN ──────────────────────────────────────
+Analizá el [ÚLTIMO COMANDO DEL USUARIO] y clasificalo:
 
-PERSONALIDAD Y TONO:
-- Profesional, directo, latencia percibida cero (respuestas EXTREMADAMENTE cortas, máximo 1-2 oraciones).
-- Ligeramente sarcástico u honesto de forma técnica si es apropiado.
-- Dirígete al usuario como "Señor".
-- NUNCA leas código, rutas de archivos largas, asteriscos, ni uses formato markdown. Habla como lo haría un humano.
+• EXPLICAR  → pide comprensión: "explícame", "qué es", "describí", "contame", "cómo funciona",
+              "qué dice", "qué tiene", "qué son", "qué hace", "dame un resumen de", "cuáles son"
+• EJECUTAR  → orden a realizar: "instalá", "creá", "borrá", "editá", "corré", "hacé", "commitear", "mostrá"
+• ESTADO    → pide resultado: "cómo va", "qué pasó", "hay errores", "terminó", "qué hay"
+• RESPUESTA → responde a Jarvis: "sí", "no", "dale", "uno", "dos", "tres", "ok", "correcto"
 
-FORMATO DE SALIDA ESTRICTO (JSON):
-Debes responder ÚNICAMENTE con un objeto JSON válido con la siguiente estructura:
+── PASO 2: REGLAS POR TIPO ───────────────────────────────────────────────────
+
+EXPLICAR → SIEMPRE hablar aunque la salida sea larga.
+  El usuario NECESITA escuchar la explicación porque no puede verla.
+  Narrá los puntos clave de forma fluida y oral, como un locutor describiendo una pantalla.
+  No leas código ni rutas de archivos. Describí conceptos, propósitos y resultados.
+  Usá 4-8 oraciones si el contenido lo justifica.
+  NO preguntes "¿desea continuar?" ni "¿quiere empezar?". Simplemente explicá el contenido.
+
+EJECUTAR → Hablar SOLO si:
+  a) La tarea completó exitosamente → una oración de confirmación.
+  b) Hay un error → describir brevemente.
+  c) Se requiere una decisión → presentarla.
+  Silencio durante: planificación, búsqueda de archivos, pasos intermedios sin resultado final.
+
+ESTADO → Hablar siempre. Resumir en 2-3 oraciones: qué pasó, si hay errores, si se necesita algo.
+
+RESPUESTA → Hablar solo si la acción ejecutada tuvo un resultado relevante (éxito, error, nueva decisión).
+
+── SIEMPRE EN SILENCIO ────────────────────────────────────────────────────────
+• Pensamientos internos (<thought>, <think>)
+• Herramientas en background sin errores (leyendo archivos, buscando sin resultado aún)
+• Planificación inicial sin resultado final todavía
+
+── PERSONALIDAD ──────────────────────────────────────────────────────────────
+• Profesional y directo. Dirigite al usuario como "Señor".
+• Para EXPLICAR: hablá como un locutor. Fluido, completo, humano.
+• Para otros tipos: muy conciso (1-2 oraciones).
+• NUNCA leas: código fuente, rutas de archivos, asteriscos, markdown, símbolos técnicos.
+
+── FORMATO JSON ESTRICTO ─────────────────────────────────────────────────────
 {
-  "reasoning": "Tu análisis interno de por qué decides hablar o guardar silencio.",
-  "should_speak": true o false,
-  "speech_content": "El texto exacto que dirás por TTS (vacío si should_speak es false)",
-  "expects_response": true o false (siempre true si haces una pregunta o pides una decisión)
+  "intent_type": "EXPLICAR|EJECUTAR|ESTADO|RESPUESTA|DESCONOCIDO",
+  "reasoning": "análisis interno de la decisión",
+  "should_speak": true|false,
+  "speech_content": "texto exacto para TTS (vacío si should_speak es false)"
 }
 """
 
@@ -76,21 +103,32 @@ Debes responder ÚNICAMENTE con un objeto JSON válido con la siguiente estructu
         last_speech = context.get("last_speech", "Ninguno")
         last_terminal = context.get("last_terminal_output", "Ninguna")
 
-        prompt = f"""Eres la inteligencia central de JARVIS. Evalúa la respuesta del usuario a tu intervención anterior.
-Tu intervención anterior: "{last_speech}"
-Última salida de terminal: "{last_terminal}"
-El usuario acaba de responder: "{user_input}"
+        prompt = f"""Eres la inteligencia central de JARVIS (asistente para usuario con discapacidad visual).
+CONTEXTO:
+- Lo que JARVIS dijo antes: "{last_speech}"
+- Lo que el usuario acaba de decir: "{user_input}"
+- Última salida de terminal (primeros 400 chars): "{str(last_terminal)[:400]}"
 
-Decide la acción más lógica:
-1. "authorize": El usuario aprueba la ejecución (ej: "sí", "dale", "ok"). 
-   - Retorna value: "1", "2" o "3" según corresponda.
-2. "answer": El usuario hace una pregunta o pide aclaración.
-   - Retorna value: (vacio, el flujo principal generará la respuesta).
-3. "type": El usuario da una nueva orden o comando directo.
-   - Retorna value: (el comando a ejecutar).
-4. "ignore": Ruido o entrada no accionable.
+CRITERIOS (en orden de prioridad):
 
-Responde ÚNICAMENTE en JSON con el formato:
+1. "authorize" — El usuario APRUEBA o ACEPTA algo.
+   Señales: "sí", "dale", "ok", "adelante", "procede", "uno", "dos", "tres", "hazlo", "correcto".
+   value: "1", "2" o "3" si hay opciones numeradas, sino "1".
+
+2. "type" — El usuario da una orden o comando NUEVO y distinto al contexto actual.
+   Señales: verbo imperativo nuevo, tema diferente al de JARVIS.
+   value: el comando exacto como lo dijo el usuario.
+
+3. "answer" — El usuario hace una pregunta, pide aclaración, o reformula lo que JARVIS dijo.
+   Señales: pregunta directa, "qué es", "explicame", "por qué", "cómo", NO entendió la respuesta anterior,
+   repite o reformula lo que JARVIS dijo (quiere que se lo expliquen mejor).
+   REGLA CLAVE: si el usuario repitió o parafraseó la pregunta de JARVIS → "answer", NUNCA "ignore".
+   value: "" (vacío).
+
+4. "ignore" — SOLO ruido puro: palabras sueltas sin sentido, onomatopeyas, silencio transcrito mal.
+   NUNCA uses "ignore" si el usuario formuló una oración completa o hizo una pregunta.
+
+Respondé ÚNICAMENTE en JSON:
 {{
   "action": "authorize|answer|type|ignore",
   "value": "string",

--- a/adapters/stt/faster_whisper_stt.py
+++ b/adapters/stt/faster_whisper_stt.py
@@ -1,0 +1,58 @@
+"""
+FasterWhisperSTT — Cross-platform STT using faster-whisper.
+
+Used on Windows, Linux, and Intel Macs where mlx-whisper is unavailable.
+Automatically selects CUDA if available, otherwise CPU with int8 quantization.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_TECH_PROMPT = (
+    "Comandos de programación en terminal. "
+    "Palabras clave: PR, Pull Request, issue, bug, branch, commit, "
+    "merge, rebase, push, pull, fetch, clone, repo, proyecto, "
+    "Python, JavaScript, React, Node, API, backend, frontend, "
+    "script, archivo, carpeta, directorio, código, refactor, "
+    "ticket, sprint, Jira, GitHub, GitLab, Claude, CLI, Jarvis. "
+    "¿Cuántos PRs abiertos tiene el proyecto? "
+    "Creame un nuevo issue para este bug."
+)
+
+
+class FasterWhisperSTT:
+    """STT adapter using faster-whisper. Works on CPU (int8) and CUDA (float16)."""
+
+    def __init__(self, model_name: str = "small") -> None:
+        from faster_whisper import WhisperModel
+
+        device = "cuda" if self._has_cuda() else "cpu"
+        compute_type = "float16" if device == "cuda" else "int8"
+        logger.info(
+            "[FasterWhisperSTT] Cargando modelo '%s' en %s (%s)",
+            model_name,
+            device,
+            compute_type,
+        )
+        self.model = WhisperModel(model_name, device=device, compute_type=compute_type)
+
+    @staticmethod
+    def _has_cuda() -> bool:
+        try:
+            import torch  # type: ignore[import]
+
+            return bool(torch.cuda.is_available())
+        except ImportError:
+            return False
+
+    def transcribe(self, audio_file_path: str) -> str:
+        """Transcribe a WAV file and return the text."""
+        segments, _ = self.model.transcribe(
+            audio_file_path,
+            language="es",
+            initial_prompt=_TECH_PROMPT,
+            temperature=0.0,
+        )
+        return "".join(s.text for s in segments).strip()

--- a/adapters/stt/ghost_typer.py
+++ b/adapters/stt/ghost_typer.py
@@ -84,9 +84,13 @@ class GhostTyper:
         if has_tmux_session:
             logging.info("Inyectando texto via tmux en background...")
             # Usar tmux send-keys con el flag -l para insertar el texto literal, asegurando que no se interpreten caracteres especiales
-            subprocess.run(["tmux", "send-keys", "-t", "jarvis_gemini", "-l", text], check=False)
-            # Enviar el Enter key
-            subprocess.run(["tmux", "send-keys", "-t", "jarvis_gemini", "Enter"], check=False)
+            result_text = subprocess.run(["tmux", "send-keys", "-t", "jarvis_gemini", "-l", text], capture_output=True)
+            time.sleep(0.15)  # 150ms para que el terminal (React/Ink) procese el texto antes del Enter
+            result_enter = subprocess.run(["tmux", "send-keys", "-t", "jarvis_gemini", "Enter"], capture_output=True)
+            if result_text.returncode != 0 or result_enter.returncode != 0:
+                logging.warning(f"tmux send-keys falló — text:{result_text.returncode} enter:{result_enter.returncode}. Stderr: {result_enter.stderr.decode().strip()}")
+            else:
+                logging.info("Texto + Enter enviados correctamente via tmux.")
             return
 
         # 1. Fallback a AppleScript: Guardar el texto en el portapapeles de Mac (es mucho más confiable que simular teclas de a una)

--- a/adapters/tts/edge_tts_adapter.py
+++ b/adapters/tts/edge_tts_adapter.py
@@ -69,8 +69,9 @@ class EdgeTTS:
                 os.remove(temp_file)
             return
 
-        # 2. Reproducir el archivo generado usando afplay (nativo de Mac)
-        self.current_process = subprocess.Popen(["afplay", temp_file])
+        # 2. Reproducir el archivo generado con el player disponible en la plataforma
+        from core.platform_utils import get_audio_player_cmd
+        self.current_process = subprocess.Popen(get_audio_player_cmd(temp_file))
 
         # Bucle de monitoreo (El corazón del Barge-in del lado del reproductor)
         while self.current_process.poll() is None:

--- a/assign_milestones.sh
+++ b/assign_milestones.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Asigna cada issue al milestone correcto
+# Uso: bash assign_milestones.sh
+set -e
+
+export PATH="/opt/homebrew/bin:$PATH"
+REPO="cr8297408/J.A.R.V.I.S"
+
+assign() {
+  local search="$1"
+  local milestone="$2"
+  local number
+  number=$(gh issue list --repo "$REPO" --search "$search in:title" --json number --jq '.[0].number' 2>/dev/null)
+  if [ -z "$number" ] || [ "$number" = "null" ]; then
+    echo "  ⚠️  No encontré issue: $search"
+    return
+  fi
+  gh issue edit "$number" --repo "$REPO" --milestone "$milestone" 2>/dev/null
+  echo "  ✅ #$number → $milestone"
+}
+
+echo "── M1: Foundation ──────────────────────────────"
+assign "[EPIC-1]" "M1: Foundation"
+assign "[EPIC-2]" "M1: Foundation"
+assign "[EPIC-3]" "M1: Foundation"
+assign "[EPIC-4]" "M1: Foundation"
+
+echo "── M2: Tool System ─────────────────────────────"
+assign "[EPIC-5]"  "M2: Tool System"
+assign "[EPIC-6]"  "M2: Tool System"
+assign "[EPIC-7]"  "M2: Tool System"
+assign "[EPIC-8]"  "M2: Tool System"
+assign "[EPIC-9]"  "M2: Tool System"
+assign "[EPIC-10]" "M2: Tool System"
+assign "[EPIC-11]" "M2: Tool System"
+assign "[EPIC-12]" "M2: Tool System"
+
+echo "── M3: Voice UX ────────────────────────────────"
+assign "[EPIC-13]" "M3: Voice UX"
+assign "[EPIC-14]" "M3: Voice UX"
+assign "[EPIC-15]" "M3: Voice UX"
+assign "[EPIC-16]" "M3: Voice UX"
+assign "[EPIC-17]" "M3: Voice UX"
+assign "[EPIC-18]" "M3: Voice UX"
+
+echo "── M4: Latency Zero ────────────────────────────"
+assign "[EPIC-19]" "M4: Latency Zero"
+assign "[EPIC-20]" "M4: Latency Zero"
+assign "[EPIC-21]" "M4: Latency Zero"
+assign "[EPIC-22]" "M4: Latency Zero"
+assign "[EPIC-23]" "M4: Latency Zero"
+
+echo "── M5: Intelligence ────────────────────────────"
+assign "[EPIC-24]" "M5: Intelligence"
+assign "[EPIC-25]" "M5: Intelligence"
+assign "[EPIC-26]" "M5: Intelligence"
+assign "[EPIC-27]" "M5: Intelligence"
+
+echo "── M6: Advanced ────────────────────────────────"
+assign "[EPIC-28]" "M6: Advanced"
+assign "[EPIC-29]" "M6: Advanced"
+assign "[EPIC-30]" "M6: Advanced"
+assign "[EPIC-31]" "M6: Advanced"
+assign "[EPIC-32]" "M6: Advanced"
+
+echo ""
+echo "✅ Listo → https://github.com/$REPO/milestones"

--- a/core/audio/vad_listener.py
+++ b/core/audio/vad_listener.py
@@ -6,9 +6,18 @@ import wave
 import subprocess
 import webrtcvad
 import asyncio
+import unicodedata
 from openwakeword.model import Model
 from adapters.stt.mlx_stt import LocalSTT
 from adapters.stt.ghost_typer import GhostTyper
+
+
+def _normalize(text: str) -> str:
+    """Minúsculas + strip acentos + eliminar puntuación básica. Usado para el filtro de alucinaciones."""
+    text = text.lower().strip()
+    text = text.replace("!", "").replace("¡", "").replace(".", "").replace(",", "").replace("?", "").replace("¿", "")
+    # Descomponer caracteres Unicode y quedarse solo con ASCII (elimina acentos)
+    return unicodedata.normalize("NFD", text).encode("ascii", "ignore").decode("ascii")
 
 active_listening_requested = threading.Event()
 jarvis_speaking = threading.Event()
@@ -83,7 +92,6 @@ def start_vad_thread(
             frames_buffer = []  # Para acumular hasta los 1280 que necesita OWW
             recording_frames = []  # Para guardar el comando entero
             silence_chunks = 0
-            speaking_duration_chunks = 0  # Contador para evitar echo inicial
             MAX_SILENCE_CHUNKS = 50  # ~1.5 segundos de silencio a 30ms por chunk
             MAX_RECORDING_CHUNKS = (
                 2000  # ~15 segundos máximo absoluto (500 * 30ms = 15s)
@@ -96,14 +104,17 @@ def start_vad_thread(
                 raw_audio = stream.read(CHUNK, exception_on_overflow=False)
 
                 if state == "WAITING_WAKEWORD":
-                    if active_listening_requested.is_set():
+                    # Solo activar el auto-trigger DESPUÉS de que Jarvis termine de hablar.
+                    # Si está activo mientras jarvis_speaking está seteado, el mic graba el
+                    # audio del altavoz (echo del TTS) y lo transcribe como un comando.
+                    if active_listening_requested.is_set() and not jarvis_speaking.is_set():
                         logging.info("Auto-triggering recording for follow-up...")
                         play_sfx("wake")
                         owwModel.reset()
+                        active_listening_requested.clear()
                         state = "RECORDING_COMMAND"
                         recording_frames = []
                         silence_chunks = 0
-                        speaking_duration_chunks = 0
                         frames_buffer = []
                         continue
 
@@ -138,12 +149,19 @@ def start_vad_thread(
                                 state = "RECORDING_COMMAND"
                                 recording_frames = []
                                 silence_chunks = 0
-                                speaking_duration_chunks = 0
                                 break  # Salir del for loop
 
                         frames_buffer = []  # Limpiar buffer corto
 
                 elif state == "RECORDING_COMMAND":
+                    # Si Jarvis está hablando, descartamos los frames acumulados.
+                    # Así evitamos que el eco del altavoz quede grabado y sea
+                    # transcripto como si fuera el usuario hablando.
+                    if jarvis_speaking.is_set():
+                        recording_frames = []
+                        silence_chunks = 0
+                        continue
+
                     recording_frames.append(raw_audio)
 
                     # 1. Calcular volumen (RMS) del chunk actual
@@ -162,19 +180,6 @@ def start_vad_thread(
                             silence_chunks += 1
                     else:
                         silence_chunks = 0  # Resetear si detecta voz real
-
-                        # Barge-in (Interrupción): Si Jarvis está hablando y detectamos voz humana fuerte,
-                        # lo cortamos al instante.
-                        if jarvis_speaking.is_set():
-                            speaking_duration_chunks += 1
-                            # Solo interrumpir después de ~750ms de habla para evitar echo inicial
-                            # y con un umbral de volumen mucho más alto (1500 RMS)
-                            if is_speech and rms > 1500 and speaking_duration_chunks > 25:
-                                if not interrupt_event.is_set():
-                                    logging.info("Barge-in detectado: Silenciando a Jarvis.")
-                                    interrupt_event.set()
-                        else:
-                            speaking_duration_chunks = 0
 
                     # Si detectó ~1.5s de silencio o pasamos el límite absoluto de tiempo
                     if (
@@ -212,9 +217,10 @@ def start_vad_thread(
 
                             logging.info(f"Voz detectada: {text}")
                             
-                            # Filtro de alucinaciones comunes de Whisper en silencio/ruido
-                            t_clean = text.lower().strip().replace("!", "").replace("¡", "").replace(".", "")
-                            if t_clean in ["suscribete", "subscribete", "gracias por ver", "gracias", "watching"]:
+                            # Filtro de alucinaciones comunes de Whisper en silencio/ruido.
+                            # _normalize() elimina acentos para que "¡Suscríbete!" == "suscribete".
+                            t_clean = _normalize(text)
+                            if t_clean in ["suscribete", "subscribete", "gracias por ver", "gracias", "watching", "subtitulos por", "transcrito por"]:
                                 logging.info(f"Hallucination filtrada: {text}")
                                 return
 
@@ -245,14 +251,31 @@ def start_vad_thread(
                                     logging.info(f"[Cerebro Jarvis] {reasoning} -> {action}")
 
                                     if action == "authorize":
-                                        GhostTyper.type_string(value if value else "1")
+                                        # Verificar que el permiso no haya expirado.
+                                        # Si pasaron más de 90s desde que llegó la notificación,
+                                        # Gemini ya procesó o descartó el permiso — no enviamos "1".
+                                        import time as _time
+                                        pending_ts = user_context.get("pending_permission_ts")
+                                        PERMISSION_TIMEOUT_SECS = 90
+                                        if pending_ts and (_time.monotonic() - pending_ts) > PERMISSION_TIMEOUT_SECS:
+                                            logging.warning(
+                                                f"Aprobación tardía descartada — "
+                                                f"{_time.monotonic() - pending_ts:.0f}s desde el permiso (límite {PERMISSION_TIMEOUT_SECS}s). "
+                                                "Gemini ya procesó o descartó la solicitud."
+                                            )
+                                            # TODO: notificar al usuario por TTS que llegó tarde
+                                        else:
+                                            user_context["pending_permission_ts"] = None
+                                            GhostTyper.type_string(value if value else "1")
                                     elif action == "type":
                                         GhostTyper.type_string(value if value else text)
+                                    elif action == "answer":
+                                        # El usuario hace una pregunta → va al terminal para que el LLM responda.
+                                        GhostTyper.type_string(text)
                                     elif action == "ignore":
                                         logging.info("Entrada ignorada.")
                                     else:
-                                        # Fallback para "answer" o desconocidos
-                                        GhostTyper.type_string(text)
+                                        logging.info(f"Acción desconocida '{action}' — ignorando para no contaminar el terminal.")
                                 except Exception as e:
                                     logging.error(f"Error evaluando respuesta: {e}")
                                     GhostTyper.type_string(text)

--- a/core/audio/vad_listener.py
+++ b/core/audio/vad_listener.py
@@ -1,5 +1,6 @@
 import pyaudio
 import numpy as np
+import sys
 import threading
 import logging
 import wave
@@ -8,7 +9,6 @@ import webrtcvad
 import asyncio
 import unicodedata
 from openwakeword.model import Model
-from adapters.stt.mlx_stt import LocalSTT
 from adapters.stt.ghost_typer import GhostTyper
 
 
@@ -26,8 +26,10 @@ jarvis_speaking = threading.Event()
 user_context = {"last_command": "", "last_speech": "", "last_terminal_output": ""}
 
 
-def play_sfx(sound_name):
-    """Reproduce sonidos nativos de Mac para feedback no bloqueante."""
+def play_sfx(sound_name: str) -> None:
+    """Reproduce feedback sonoro no bloqueante. Solo en macOS (afplay)."""
+    if sys.platform != "darwin":
+        return
     sounds = {
         "wake": "/System/Library/Sounds/Ping.aiff",
         "stop": "/System/Library/Sounds/Pop.aiff",
@@ -60,7 +62,8 @@ def start_vad_thread(
         try:
             # Los modelos ahora están descargados correctamente dentro del paquete de openwakeword
             owwModel = Model(wakeword_models=["hey_jarvis"], inference_framework="onnx")
-            stt_engine = LocalSTT()
+            from core.platform_utils import get_stt_class
+            stt_engine = get_stt_class()()
             vad = webrtcvad.Vad(3)  # Agresividad MÁXIMA (3) para ignorar ruido de fondo
         except Exception as e:
             logging.error(f"Fallo cargando modelos: {e}")

--- a/core/audio/vad_listener.py
+++ b/core/audio/vad_listener.py
@@ -30,7 +30,11 @@ def play_sfx(sound_name):
 
 
 def start_vad_thread(
-    interrupt_event: threading.Event, summarizer=None, tts=None, loop=None
+    interrupt_event: threading.Event,
+    summarizer=None,
+    tts=None,
+    loop=None,
+    on_transcription=None,
 ):
     """
     Máquina de estados de Escucha Activa:
@@ -216,7 +220,12 @@ def start_vad_thread(
 
                             user_context["last_command"] = text
 
-                            # Evaluación inteligente si hay un summarizer
+                            # Modo API: callback directo, sin GhostTyper ni PTY
+                            if on_transcription is not None:
+                                on_transcription(text)
+                                return
+
+                            # Modo PTY: evaluación inteligente con el summarizer
                             if (
                                 summarizer
                                 and loop

--- a/core/input/hotkey_listener.py
+++ b/core/input/hotkey_listener.py
@@ -1,0 +1,77 @@
+"""
+HotkeyListener — Atajo de teclado global para detener ejecuciones de Jarvis.
+
+Reemplaza el barge-in por VAD (sensible al ruido de fondo) con un shortcut
+deliberado del teclado.
+
+Shortcut por defecto: Ctrl+Shift+T
+Configurable vía variable de entorno: JARVIS_STOP_HOTKEY
+  Ej: JARVIS_STOP_HOTKEY="<ctrl>+<shift>+t"
+
+Nota macOS: pynput requiere permiso de Accesibilidad.
+  Sistema > Privacidad y Seguridad > Accesibilidad → agregar la terminal.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOTKEY = "<ctrl>+<shift>+t"
+
+
+class HotkeyListener:
+    """
+    Escucha un hotkey global y llama a `on_stop` cuando se presiona.
+    Corre en un hilo demonio para no bloquear el event loop principal.
+    """
+
+    def __init__(
+        self,
+        on_stop: Callable[[], None],
+        hotkey: str | None = None,
+    ) -> None:
+        self._on_stop = on_stop
+        self._hotkey = hotkey or os.getenv("JARVIS_STOP_HOTKEY", DEFAULT_HOTKEY)
+        self._thread: threading.Thread | None = None
+        self._listener = None
+
+    # ── API pública ───────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Inicia el listener en un hilo demonio."""
+        self._thread = threading.Thread(target=self._run, daemon=True, name="hotkey-listener")
+        self._thread.start()
+        logger.info(f"[Hotkey] Escuchando '{self._hotkey}' para detener ejecución.")
+
+    def stop(self) -> None:
+        """Detiene el listener limpiamente."""
+        if self._listener is not None:
+            try:
+                self._listener.stop()
+            except Exception:
+                pass
+
+    # ── Internals ─────────────────────────────────────────────────────────────
+
+    def _run(self) -> None:
+        try:
+            from pynput import keyboard
+
+            def _trigger():
+                logger.info(f"[Hotkey] '{self._hotkey}' presionado — deteniendo ejecución.")
+                self._on_stop()
+
+            self._listener = keyboard.GlobalHotKeys({self._hotkey: _trigger})
+            self._listener.run()
+
+        except ImportError:
+            logger.error(
+                "[Hotkey] pynput no instalado. "
+                "Ejecutá: pip install pynput"
+            )
+        except Exception as e:
+            logger.error(f"[Hotkey] Error inesperado: {e}")

--- a/core/platform_utils.py
+++ b/core/platform_utils.py
@@ -1,0 +1,111 @@
+"""
+Platform detection utilities for adapter auto-selection.
+
+Import this module instead of importing platform-specific adapters directly.
+All adapter selections respect the ACTIVE_STT_ENGINE / ACTIVE_TTS_ENGINE env vars,
+falling back to the best available adapter for the current OS/hardware.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import sys
+
+
+# ── Platform predicates ────────────────────────────────────────────────────────
+
+def is_apple_silicon() -> bool:
+    """True on macOS running on Apple Silicon (M1/M2/M3/M4)."""
+    return sys.platform == "darwin" and platform.machine() == "arm64"
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+def is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def is_linux() -> bool:
+    return sys.platform.startswith("linux")
+
+
+# ── Adapter selection ──────────────────────────────────────────────────────────
+
+def get_stt_class():
+    """
+    Returns the STT class best suited for the current platform.
+
+    Selection order:
+    1. ACTIVE_STT_ENGINE env var (explicit override)
+    2. mlx_whisper  — if Apple Silicon
+    3. faster_whisper — everywhere else (CPU int8 / CUDA float16)
+    """
+    engine = _env("ACTIVE_STT_ENGINE")
+
+    if engine == "mlx_whisper" or (not engine and is_apple_silicon()):
+        from adapters.stt.mlx_stt import LocalSTT  # type: ignore[import]
+        return LocalSTT
+
+    from adapters.stt.faster_whisper_stt import FasterWhisperSTT
+    return FasterWhisperSTT
+
+
+def get_tts_class():
+    """
+    Returns the TTS class best suited for the current platform.
+
+    Selection order:
+    1. ACTIVE_TTS_ENGINE env var (explicit override)
+    2. mac_say  — if macOS (zero latency, no network)
+    3. edge_tts — everywhere else (neural voice, requires network)
+    """
+    engine = _env("ACTIVE_TTS_ENGINE")
+
+    if engine == "mac_say" or (not engine and is_macos()):
+        from adapters.tts.mac_say_tts import MacSayTTS  # type: ignore[import]
+        return MacSayTTS
+
+    from adapters.tts.edge_tts_adapter import EdgeTTS
+    return EdgeTTS
+
+
+# ── Audio playback ─────────────────────────────────────────────────────────────
+
+def get_audio_player_cmd(file_path: str) -> list[str]:
+    """
+    Returns the shell command to play an audio file on the current platform.
+    Prefers ffplay (cross-platform) then falls back to native players.
+    """
+    import shutil
+
+    if is_macos():
+        return ["afplay", file_path]
+
+    if is_windows():
+        # PowerShell MediaPlayer handles MP3 natively
+        return [
+            "powershell",
+            "-c",
+            f"(New-Object Media.SoundPlayer '{file_path}').PlaySync()",
+        ]
+
+    # Linux: ffplay > mpg123 > aplay (aplay is WAV-only, last resort)
+    for player, args in [
+        ("ffplay", ["-nodisp", "-autoexit", file_path]),
+        ("mpg123", [file_path]),
+        ("aplay", [file_path]),
+    ]:
+        if shutil.which(player):
+            return [player] + (args[:-1] if player == "aplay" else args)
+
+    raise RuntimeError(
+        "No audio player found. Install ffmpeg: sudo apt-get install ffmpeg"
+    )
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _env(key: str) -> str:
+    return os.getenv(key, "").strip().lower()

--- a/core/server/jarvis_daemon.py
+++ b/core/server/jarvis_daemon.py
@@ -3,6 +3,7 @@ import os
 import asyncio
 import threading
 import logging
+import time
 
 # Configurar logs básicos para el Daemon
 logging.basicConfig(
@@ -149,9 +150,15 @@ async def process_text_queue():
                     if payload.get("notification_type") == "ToolPermission":
                         # Extraer mensaje de la notificación y detalles
                         details = payload.get("details", {})
-                        
+
                         # Inyectar el directorio actual de invocación para que la IA sepa dónde está "parada"
                         details["cwd_context"] = os.getenv("JARVIS_INVOCATION_DIR", os.getcwd())
+
+                        # Registrar cuándo llegó el permiso para detectar aprobaciones tardías
+                        permission_timestamp = time.monotonic()
+                        user_context["pending_permission_ts"] = permission_timestamp
+                        # Timeout: si el usuario tarda más de 90s, el permiso se considera expirado
+                        PERMISSION_TIMEOUT_SECS = 90
 
                         logging.info(
                             f"Notificación de herramienta detectada. Detalles: {details}. Solicitando resumen a IA..."

--- a/core/session/claude_code_pty_session.py
+++ b/core/session/claude_code_pty_session.py
@@ -1,0 +1,234 @@
+"""
+ClaudeCodePtySession — PTY wrapper para Claude Code CLI.
+
+Mismo patrón que main.py (Gemini), pero con filtros TUI específicos
+para el React/Ink renderer de Claude Code.
+
+Flujo:
+    User speaks → VAD → Whisper → GhostTyper → PTY(claude) → TUI filter → TTS
+"""
+from __future__ import annotations
+
+import os
+import sys
+import select
+import tty
+import termios
+import threading
+import asyncio
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+# ── Regex para limpiar ruido de la terminal ───────────────────────────────────
+
+ANSI_CLEANER = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+BOX_DRAWING_CLEANER = re.compile(
+    r"[─━│┃┄┅┆┇┈┉┊┋┌┍┎┏┐┑┒┓└┕┖┗┘┙┚┛├┝┞┟┠┡┢┣┤┥┦┧┨┩┪┫┬┭┮┯┰┱┲┳┴┵┶┷┸┹┺┻┼┽┾┿╀╁╂╃╄╅╆╇╈╉╊╋═║╒╓╔╕╖╗╘╙╚╛╜╝╞╟╠╡╢╣╤╥╦╧╨╩╪╫╬╭╮╯╰╱╲╳╴╵╶╷╸╹╺╻╼╽╾╿▀▂▃▄▅▆▇█▉▊▋▌▍▎▏▐░▒▓▔▕▖▗▘▙▚▛▜▝▞▟]+"
+)
+TITLE_CLEANER = re.compile(r"\x1b\]0;.*?\x07")
+
+# Spinner Braille que usa Ink/React para loading indicators
+SPINNER_CLEANER = re.compile(r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]+")
+
+# ── Filtros específicos de Claude Code TUI ────────────────────────────────────
+
+# Si una línea contiene CUALQUIERA de estas cadenas, se descarta COMPLETA.
+# Son artefactos del React/Ink renderer de Claude Code.
+TUI_BLACKLIST = [
+    # Hints de teclado (status bar inferior)
+    "Press Esc",
+    "for newline",
+    "! for bash",
+    "? for help",
+    "shift+tab",
+    "auto-accept edits",
+    "⏎",
+    # Información del modelo en el header
+    "Claude Code",
+    "claude.ai/code",
+    # Contadores de costo y tokens
+    "Cost: $",
+    "tokens",
+    "input tokens",
+    "output tokens",
+    # Decoradores de tool calls que no son contenido útil
+    "Running tool",
+    "Tool result",
+    "bash(",
+    "read_file(",
+    "write_file(",
+    "list_files(",
+    "search_files(",
+    # Prompt vacío
+    "◯",
+    "●",
+]
+
+
+def clean_and_filter_chunk(raw_chunk: str) -> str:
+    """
+    Filtra el chunk de salida de Claude Code CLI:
+    - Elimina códigos ANSI, box drawing, títulos de ventana
+    - Elimina spinners Braille
+    - Descarta líneas que son puro chrome del TUI
+    - Preserva el contenido real de la respuesta
+    """
+    normalized = raw_chunk.replace("\r\n", "\n").replace("\r", "\n")
+    lines = normalized.split("\n")
+    valid_lines = []
+
+    for line in lines:
+        # 1. Eliminar escape sequences de color/posición
+        clean = ANSI_CLEANER.sub("", line)
+
+        # 2. Filtrar por contenido de directorio actual
+        current_dir = os.path.basename(os.getcwd())
+        if current_dir in clean:
+            continue
+
+        # 3. Guillotina: si la línea tiene chrome del TUI, vuela completa
+        if any(bad in clean for bad in TUI_BLACKLIST):
+            continue
+
+        # 4. Eliminar box drawing, títulos, spinners
+        clean = BOX_DRAWING_CLEANER.sub("", clean)
+        clean = TITLE_CLEANER.sub("", clean)
+        clean = SPINNER_CLEANER.sub("", clean)
+
+        # 5. Limpiar símbolos decorativos de Claude Code
+        clean = clean.replace("✓", "").replace("✗", "").replace("►", "")
+        clean = clean.replace("▶", "").replace("·", "").strip()
+
+        # 6. Descartar líneas vacías o que son solo el prompt ">"
+        if len(clean) < 2 and clean in ("", ">", "$"):
+            continue
+
+        valid_lines.append(clean)
+
+    return " ".join(valid_lines).strip()
+
+
+# ── Sesión PTY ────────────────────────────────────────────────────────────────
+
+class ClaudeCodePtySession:
+    """
+    Wrapper PTY para Claude Code CLI con overlay de voz.
+
+    Uso:
+        session = ClaudeCodePtySession()
+        session.run()  # bloqueante hasta Ctrl+C
+    """
+
+    def __init__(self) -> None:
+        from adapters.tts.mac_say_tts import MacSayTTS
+        from core.lexer.poc_lexer import StreamingLexer
+
+        self.tts = MacSayTTS()
+        self.interrupt_event = threading.Event()
+        self._lexer_class = StreamingLexer
+
+    def run(self) -> None:
+        """Inicia la sesión PTY. Bloqueante hasta Ctrl+C."""
+        from core.cli.pty_wrapper import PtyCLIWrapper
+        from core.audio.vad_listener import start_vad_thread
+
+        print("\r\n[J.A.R.V.I.S] Modo PTY — Claude Code. Inicializando...\r\n")
+
+        # Arrancar cerebro async en su hilo
+        brain_loop = asyncio.new_event_loop()
+        text_queue: asyncio.Queue = asyncio.Queue()
+        threading.Thread(
+            target=self._brain_thread,
+            args=(text_queue, brain_loop),
+            daemon=True,
+        ).start()
+
+        # Arrancar VAD (usa GhostTyper para inyectar voz en el PTY)
+        start_vad_thread(self.interrupt_event)
+
+        # Iniciar el wrapper PTY
+        wrapper = PtyCLIWrapper(["claude"])
+
+        try:
+            old_tty = termios.tcgetattr(sys.stdin.fileno())
+        except Exception:
+            old_tty = None
+
+        try:
+            wrapper.start()
+            tty.setraw(sys.stdin.fileno())
+
+            is_user_typing = True
+
+            while wrapper.running and wrapper.fd is not None:
+                rlist, _, _ = select.select([sys.stdin, wrapper.fd], [], [], 0.05)
+
+                # Teclado → PTY
+                if sys.stdin in rlist:
+                    char = os.read(sys.stdin.fileno(), 1)
+                    if not char:
+                        break
+
+                    if char == b"\x03":  # Ctrl+C
+                        raise KeyboardInterrupt
+
+                    if char in (b"\r", b"\n"):
+                        is_user_typing = False
+                        self.interrupt_event.set()
+                    else:
+                        is_user_typing = True
+                        self.interrupt_event.set()
+
+                    os.write(wrapper.fd, char)
+
+                # PTY → pantalla + TTS
+                if wrapper.fd in rlist:
+                    chunk = wrapper.read_stream_non_blocking()
+                    if chunk:
+                        sys.stdout.write(chunk)
+                        sys.stdout.flush()
+
+                        if is_user_typing:
+                            continue
+
+                        clean_chunk = clean_and_filter_chunk(chunk)
+                        if clean_chunk:
+                            brain_loop.call_soon_threadsafe(
+                                text_queue.put_nowait, clean_chunk
+                            )
+
+        except KeyboardInterrupt:
+            logger.info("Sesión PTY Claude Code terminada por el usuario.")
+        finally:
+            if old_tty:
+                termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, old_tty)
+            wrapper.stop()
+
+    def _brain_thread(self, text_queue: asyncio.Queue, loop: asyncio.AbstractEventLoop) -> None:
+        """Hilo del cerebro: Lexer → TTS."""
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(self._brain_async_loop(text_queue))
+
+    async def _brain_async_loop(self, text_queue: asyncio.Queue) -> None:
+        """Lee texto limpio de la cola, lo parsea y lo habla."""
+        lexer = self._lexer_class()
+
+        while True:
+            chunk = await text_queue.get()
+
+            if self.interrupt_event.is_set():
+                lexer.buffer = ""
+                lexer.in_code_block = False
+                self.interrupt_event.clear()
+
+            chunk_type, content = await lexer.process_token(chunk)
+
+            if chunk_type == "TEXT_CHUNK":
+                self.tts.speak(content, self.interrupt_event)
+            elif chunk_type == "CODE_BLOCK":
+                # En PTY mode los bloques de código se saltan igual que en main.py
+                lines = len(content.splitlines())
+                summary = f"Bloque de código de {lines} líneas."
+                self.tts.speak(summary, self.interrupt_event)

--- a/core/session/jarvis_api_session.py
+++ b/core/session/jarvis_api_session.py
@@ -1,0 +1,98 @@
+"""
+JarvisAPISession — Sesión en modo API (sin PTY).
+
+Flujo completo:
+    Wake word → Whisper STT → ClaudeAPIAdapter (streaming) → Lexer → TTS
+
+Es el reemplazo del daemon para el backend 'claude'.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class JarvisAPISession:
+    """
+    Orquestador para el modo API.
+    Conecta VAD → Claude → TTS sin ningún proceso PTY externo.
+    """
+
+    def __init__(self, model: str = "smart") -> None:
+        from adapters.llm.claude_api_adapter import ClaudeAPIAdapter
+        from adapters.tts.mac_say_tts import MacSayTTS
+
+        self.claude = ClaudeAPIAdapter(model=model)
+        self.tts = MacSayTTS()
+        self.interrupt_event = threading.Event()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    # ── Punto de entrada ──────────────────────────────────────────────────────
+
+    def run(self) -> None:
+        """Inicia la sesión. Bloqueante hasta Ctrl+C."""
+        print("\r\n[J.A.R.V.I.S] Modo API — Claude directo. Di 'Hey Jarvis' para empezar.\r\n")
+
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+
+        # Arrancar el VAD en un hilo demonio con nuestro callback
+        from core.audio.vad_listener import start_vad_thread
+        start_vad_thread(
+            interrupt_event=self.interrupt_event,
+            on_transcription=self._on_user_speech,
+            loop=self._loop,
+        )
+
+        try:
+            self._loop.run_forever()
+        except KeyboardInterrupt:
+            logger.info("Sesión API terminada por el usuario.")
+        finally:
+            self._loop.close()
+
+    # ── Callback de transcripción ─────────────────────────────────────────────
+
+    def _on_user_speech(self, text: str) -> None:
+        """
+        Llamado desde el hilo del VAD cuando el usuario termina de hablar.
+        Despacha el mensaje a Claude en el event loop principal.
+        """
+        if not self._loop:
+            return
+        asyncio.run_coroutine_threadsafe(
+            self._process_message(text),
+            self._loop,
+        )
+
+    # ── Pipeline principal ────────────────────────────────────────────────────
+
+    async def _process_message(self, user_message: str) -> None:
+        """
+        Envía el mensaje a Claude y habla la respuesta en streaming.
+        Barge-in: si interrupt_event se activa, para de hablar.
+        """
+        logger.info(f"Mensaje del usuario: {user_message}")
+
+        # Limpiar el evento por si quedó de una interrupción anterior
+        self.interrupt_event.clear()
+
+        async for chunk_type, content in self.claude.stream_response(user_message):
+            # Si el usuario interrumpió mientras Claude generaba, cortamos
+            if self.interrupt_event.is_set():
+                logger.info("Barge-in durante generación — cortando respuesta.")
+                self.claude._history.pop()  # Descartamos la respuesta incompleta
+                break
+
+            if chunk_type == "TEXT_CHUNK":
+                await asyncio.to_thread(self.tts.speak, content, self.interrupt_event)
+
+            elif chunk_type == "CODE_BLOCK":
+                # Por ahora resumimos el bloque con una descripción genérica.
+                # Issue #7 (FileReadTool) y #25 (Smart Summarizer) lo mejoran.
+                summary = f"Acá generé un bloque de código con {len(content.splitlines())} líneas."
+                await asyncio.to_thread(self.tts.speak, summary, self.interrupt_event)

--- a/core/session/jarvis_api_session.py
+++ b/core/session/jarvis_api_session.py
@@ -30,15 +30,27 @@ class JarvisAPISession:
         self.tts = MacSayTTS()
         self.interrupt_event = threading.Event()
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._hotkey_listener = None
 
     # ── Punto de entrada ──────────────────────────────────────────────────────
 
     def run(self) -> None:
         """Inicia la sesión. Bloqueante hasta Ctrl+C."""
-        print("\r\n[J.A.R.V.I.S] Modo API — Claude directo. Di 'Hey Jarvis' para empezar.\r\n")
+        from core.input.hotkey_listener import HotkeyListener, DEFAULT_HOTKEY
+        import os
+        hotkey = os.getenv("JARVIS_STOP_HOTKEY", DEFAULT_HOTKEY)
+        print(
+            f"\r\n[J.A.R.V.I.S] Modo API — Claude directo. "
+            f"Di 'Hey Jarvis' para empezar.\r\n"
+            f"[J.A.R.V.I.S] Presioná {hotkey} para detener una respuesta en curso.\r\n"
+        )
 
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
+
+        # Hotkey global para detener ejecuciones (reemplaza el barge-in por VAD)
+        self._hotkey_listener = HotkeyListener(on_stop=self.interrupt_event.set)
+        self._hotkey_listener.start()
 
         # Arrancar el VAD en un hilo demonio con nuestro callback
         from core.audio.vad_listener import start_vad_thread
@@ -53,6 +65,7 @@ class JarvisAPISession:
         except KeyboardInterrupt:
             logger.info("Sesión API terminada por el usuario.")
         finally:
+            self._hotkey_listener.stop()
             self._loop.close()
 
     # ── Callback de transcripción ─────────────────────────────────────────────

--- a/core/session/jarvis_api_session.py
+++ b/core/session/jarvis_api_session.py
@@ -24,10 +24,10 @@ class JarvisAPISession:
 
     def __init__(self, model: str = "smart") -> None:
         from adapters.llm.claude_api_adapter import ClaudeAPIAdapter
-        from adapters.tts.mac_say_tts import MacSayTTS
+        from core.platform_utils import get_tts_class
 
         self.claude = ClaudeAPIAdapter(model=model)
-        self.tts = MacSayTTS()
+        self.tts = get_tts_class()()
         self.interrupt_event = threading.Event()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._hotkey_listener = None
@@ -67,6 +67,13 @@ class JarvisAPISession:
         finally:
             self._hotkey_listener.stop()
             self._loop.close()
+
+    def stop(self) -> None:
+        """Detiene la sesión de forma limpia desde un hilo externo (ej: system tray)."""
+        if self._loop and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._hotkey_listener:
+            self._hotkey_listener.stop()
 
     # ── Callback de transcripción ─────────────────────────────────────────────
 

--- a/core/session/jarvis_api_session.py
+++ b/core/session/jarvis_api_session.py
@@ -85,7 +85,7 @@ class JarvisAPISession:
             # Si el usuario interrumpió mientras Claude generaba, cortamos
             if self.interrupt_event.is_set():
                 logger.info("Barge-in durante generación — cortando respuesta.")
-                self.claude._history.pop()  # Descartamos la respuesta incompleta
+                self.claude.abort_last_turn()  # Fix #1: API pública, revierte solo si el turno quedó huérfano
                 break
 
             if chunk_type == "TEXT_CHUNK":

--- a/create_issues.sh
+++ b/create_issues.sh
@@ -1,0 +1,880 @@
+#!/usr/bin/env bash
+# Crea todas las issues del roadmap JARVIS Voice Coding CLI
+# Uso: bash create_issues.sh
+# Requiere: gh auth login (ejecutar una vez antes)
+
+set -e
+REPO="cr8297408/J.A.R.V.I.S"
+
+echo "Creando labels..."
+gh label create "epic:foundation"     --color "#0075ca" --description "Core CLI infrastructure" --repo $REPO 2>/dev/null || true
+gh label create "epic:tools"          --color "#e4e669" --description "Voice-adapted coding tools" --repo $REPO 2>/dev/null || true
+gh label create "epic:voice-ux"       --color "#d93f0b" --description "Voice UX for coding" --repo $REPO 2>/dev/null || true
+gh label create "epic:latency"        --color "#0e8a16" --description "Latency optimizations" --repo $REPO 2>/dev/null || true
+gh label create "epic:intelligence"   --color "#5319e7" --description "Code context intelligence" --repo $REPO 2>/dev/null || true
+gh label create "epic:advanced"       --color "#b60205" --description "Advanced features" --repo $REPO 2>/dev/null || true
+gh label create "priority:critical"   --color "#b60205" --description "Must have for MVP" --repo $REPO 2>/dev/null || true
+gh label create "priority:high"       --color "#d93f0b" --description "Sprint deliverable" --repo $REPO 2>/dev/null || true
+gh label create "priority:medium"     --color "#e4e669" --description "Next sprint" --repo $REPO 2>/dev/null || true
+gh label create "priority:low"        --color "#0075ca" --description "Backlog" --repo $REPO 2>/dev/null || true
+
+echo "Creando milestones..."
+gh api repos/$REPO/milestones -f title="M1: Foundation" -f description="Jarvis como CLI standalone con Claude API" 2>/dev/null || true
+gh api repos/$REPO/milestones -f title="M2: Tool System" -f description="Herramientas de coding adaptadas para voz" 2>/dev/null || true
+gh api repos/$REPO/milestones -f title="M3: Voice UX" -f description="UX de voz específico para programar" 2>/dev/null || true
+gh api repos/$REPO/milestones -f title="M4: Latency Zero" -f description="Optimizaciones de latencia agresivas" 2>/dev/null || true
+gh api repos/$REPO/milestones -f title="M5: Intelligence" -f description="Conciencia de contexto de código" 2>/dev/null || true
+gh api repos/$REPO/milestones -f title="M6: Advanced" -f description="Multi-agente, MCP, LSP" 2>/dev/null || true
+
+echo "Creando issues..."
+
+# ── EPIC 1: Foundation ─────────────────────────────────────────────────────
+
+gh issue create --repo $REPO \
+  --title "[EPIC-1] Refactor entry point as standalone \`jarvis\` CLI" \
+  --label "epic:foundation,priority:critical" \
+  --body "## Objetivo
+Jarvis debe ser instalable como comando global (\`pip install -e .\`) y soportar subcomandos.
+
+## Tasks
+- [ ] Crear \`pyproject.toml\` con entry point \`jarvis = main:cli\`
+- [ ] Refactorizar \`main.py\` con subcomandos: \`jarvis start\`, \`jarvis config\`, \`jarvis doctor\`
+- [ ] Agregar \`--backend\` flag: \`claude\` | \`gemini\` | \`groq\`
+- [ ] Help text por voz: decir 'jarvis help' habla los comandos disponibles
+- [ ] Validación de env vars al startup con mensajes de error claros por voz
+
+## Latency impact
+Ninguno (infraestructura pura)
+
+## Definition of Done
+- \`pipx install .\` instala el comando \`jarvis\`
+- \`jarvis start\` arranca el sistema de voz
+- \`jarvis doctor\` verifica APIs, audio, modelos"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-2] Claude API direct integration — replace PTY with streaming API" \
+  --label "epic:foundation,priority:critical" \
+  --body "## Objetivo
+Reemplazar el PTY wrapper de Gemini CLI con llamadas directas a la Claude API con streaming. El PTY queda como fallback opcional.
+
+## Tasks
+- [ ] Crear \`adapters/llm/claude_api_adapter.py\` con \`anthropic\` SDK
+- [ ] Implementar streaming response handler (chunks → lexer existente)
+- [ ] Adaptar \`poc_lexer.py\` para manejar API response (no PTY output)
+- [ ] Tool use loop: detectar tool calls en el stream, ejecutar, enviar result
+- [ ] Mantener historial de conversación en memoria (multi-turn)
+- [ ] Configurar modelos: \`claude-opus-4-6\` para razonamiento, \`claude-haiku-4-5\` para clasificación
+
+## Latency impact
+**CRÍTICO** — streaming desde primer token, TTS empieza antes de que termine la respuesta completa.
+
+## Definition of Done
+- Usuario habla → Jarvis responde via Claude API en streaming
+- Primer token hablado en < 500ms desde fin del speech
+- Tool calls detectados y ejecutados en el loop"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-3] Multi-backend CLI adapter (API mode + PTY mode)" \
+  --label "epic:foundation,priority:high" \
+  --body "## Objetivo
+Soportar tres modos de operación con la misma interfaz interna.
+
+\`\`\`
+MODE=api       → llama directamente Claude/Gemini API (mínima latencia)
+MODE=pty       → wrappea un CLI externo (Claude Code CLI, Gemini CLI)
+MODE=hybrid    → API para reasoning, PTY para tool execution
+\`\`\`
+
+## Tasks
+- [ ] Crear \`core/backend/\` con \`BackendBase\`, \`APIBackend\`, \`PTYBackend\`
+- [ ] Factory pattern seleccionable via \`JARVIS_MODE\` env var o \`--mode\` flag
+- [ ] Ambos backends emiten eventos al mismo lexer/TTS pipeline
+- [ ] Tests de smoke para cada modo
+
+## Definition of Done
+- \`jarvis start --mode api\` usa Claude API directamente
+- \`jarvis start --mode pty --cli gemini\` wrappea Gemini CLI
+- Misma experiencia de voz en ambos modos"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-4] Unified configuration system (YAML + env vars + voice)" \
+  --label "epic:foundation,priority:high" \
+  --body "## Objetivo
+Sistema de configuración unificado con soporte para cambios por voz.
+
+## Tasks
+- [ ] \`~/.jarvis/config.yaml\` como config persistente
+- [ ] Schema validado con \`pydantic\`
+- [ ] Voice config: 'jarvis, cambiá la voz a Alloy', 'jarvis, usá Groq para clasificación'
+- [ ] Hot reload de config sin reiniciar el proceso
+- [ ] \`jarvis doctor\` verifica config, APIs keys, audio devices, modelos descargados
+- [ ] Config por proyecto: \`.jarvis.yaml\` en el root del proyecto
+
+## Definition of Done
+- Config válida al startup, errores claros si falta algo
+- Cambios de config por voz persisten entre sesiones"
+
+# ── EPIC 2: Tool System ────────────────────────────────────────────────────
+
+gh issue create --repo $REPO \
+  --title "[EPIC-5] Tool registry — pluggable voice tool system" \
+  --label "epic:tools,priority:critical" \
+  --body "## Objetivo
+Base para todos los tools de coding. Inspirado en Claude Code pero adaptado para voz.
+
+## Interface
+\`\`\`python
+class VoiceTool:
+    name: str
+    description: str          # Para el system prompt de Claude
+    voice_triggers: list[str] # Frases naturales que activan este tool
+    requires_confirmation: bool
+
+    async def execute(self, params: dict) -> ToolResult
+    def summarize_result(self, result: ToolResult) -> str  # Para TTS
+\`\`\`
+
+## Tasks
+- [ ] Crear \`core/tools/base.py\` con \`VoiceTool\` base class y \`ToolResult\`
+- [ ] Crear \`core/tools/registry.py\` — registro y auto-discovery de tools
+- [ ] Tool result → voice summarizer pipeline
+- [ ] Tool execution con timeout configurable y error handling
+- [ ] Logging de tool calls para debugging y métricas
+
+## Definition of Done
+- Nueva tool se registra decorando la clase con \`@registry.register\`
+- Tools disponibles se inyectan automáticamente en el system prompt de Claude"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-6] BashTool — execute shell commands via voice" \
+  --label "epic:tools,priority:high" \
+  --body "## Objetivo
+Ejecutar comandos de shell por voz con streaming output.
+
+## Ejemplos de uso
+\`\`\`
+'corré npm test'
+'instalá la dependencia axios'
+'mostrá el log de docker'
+'compilá el proyecto'
+\`\`\`
+
+## Tasks
+- [ ] \`core/tools/bash_tool.py\` con subprocess + streaming output
+- [ ] Safety gate: lista de comandos peligrosos requieren confirmación por voz (rm -rf, DROP TABLE, etc.)
+- [ ] Output streaming → lexer → TTS (escuchar output en tiempo real)
+- [ ] Timeout configurable (default: 30s)
+- [ ] Working directory awareness: sabe en qué dir estás
+- [ ] Detectar prompts interactivos y preguntar al usuario
+
+## Latency impact
+**ALTO** — streaming de output: el usuario escucha mientras se ejecuta
+
+## Definition of Done
+- 'corré npm test' ejecuta y narra el output en tiempo real
+- Comandos peligrosos requieren confirmación vocal antes de ejecutar"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-7] FileReadTool — read and intelligently summarize files via voice" \
+  --label "epic:tools,priority:high" \
+  --body "## Objetivo
+Leer archivos de código y resumirlos de forma vocal inteligente. NUNCA leer código crudo.
+
+## Ejemplos de uso
+\`\`\`
+'leé el archivo main.py'
+'explicame qué hace el archivo de configuración'
+'mostrá las primeras 50 líneas de app.ts'
+'qué hace la función authenticate?'
+\`\`\`
+
+## Tasks
+- [ ] \`core/tools/file_read_tool.py\`
+- [ ] Nunca leer archivo completo en voz — siempre pasar por LLM para resumir
+- [ ] Para archivos grandes: chunking inteligente, resumir sección relevante
+- [ ] Soporte para imágenes (descripción), PDFs (summary), Jupyter notebooks
+- [ ] Query específica: 'qué hace la función X' → extrae y explica solo esa función
+
+## Definition of Done
+- 'leé main.py' → Jarvis explica qué hace el archivo en 2-3 oraciones
+- Para archivos > 1000 líneas, pregunta qué parte querés escuchar"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-8] FileWriteTool — create files via voice dictation" \
+  --label "epic:tools,priority:high" \
+  --body "## Objetivo
+Crear archivos nuevos dictándolos por voz.
+
+## Ejemplos de uso
+\`\`\`
+'creá un archivo llamado utils.py con una función que convierte celsius a fahrenheit'
+'creá el archivo README con lo que acabamos de hacer'
+'generá un componente React Button básico'
+\`\`\`
+
+## Tasks
+- [ ] \`core/tools/file_write_tool.py\`
+- [ ] Confirmación por voz antes de escribir: '¿Confirmo que creo utils.py con X?'
+- [ ] Preview verbal del contenido antes de escribir (descripción, no el código)
+- [ ] Soporte para templates de proyecto (componente React, route FastAPI, etc.)
+- [ ] Undo: 'deshacé eso' → elimina el archivo recién creado
+
+## Definition of Done
+- Usuario describe el archivo → Claude lo genera → Jarvis confirma y lo crea
+- Archivo queda en el filesystem, Jarvis confirma la creación"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-9] FileEditTool — edit existing files via voice description" \
+  --label "epic:tools,priority:high" \
+  --body "## Objetivo
+Modificar archivos existentes describiendo los cambios en lenguaje natural.
+
+## Ejemplos de uso
+\`\`\`
+'en main.py, cambiá la función login para que use JWT'
+'agregá validación de email a la función register'
+'refactorizá el for loop en línea 45 para usar list comprehension'
+'reemplazá todos los var por const en el archivo'
+\`\`\`
+
+## Tasks
+- [ ] \`core/tools/file_edit_tool.py\`
+- [ ] Claude genera el diff, Jarvis lo aplica vía string replacement
+- [ ] Descripción vocal del cambio propuesto ANTES de aplicar
+- [ ] Confirmación: '¿Aplicás el cambio?' → 'sí' | 'no, cambiá X'
+- [ ] Undo por voz: 'deshacé el último cambio' → revert via git
+- [ ] Diff summary vocal después de aplicar
+
+## Definition of Done
+- Usuario describe cambio → Jarvis aplica el diff → confirma qué cambió
+- Undo disponible en la misma sesión"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-10] SearchTool — voice code search (ripgrep + glob)" \
+  --label "epic:tools,priority:high" \
+  --body "## Objetivo
+Buscar en el código por voz y narrar resultados relevantes.
+
+## Ejemplos de uso
+\`\`\`
+'buscá dónde se usa la función authenticate'
+'encontrá todos los archivos TypeScript con useEffect'
+'buscá TODO comments en el proyecto'
+'encontrá archivos modificados en las últimas 24 horas'
+\`\`\`
+
+## Tasks
+- [ ] \`core/tools/search_tool.py\` con \`rg\` (ripgrep) bajo el capó
+- [ ] Glob para file patterns, Grep para content search
+- [ ] Resultados resumidos por voz: 'Encontré 5 archivos. El más relevante es...'
+- [ ] 'andá al resultado 1' → abre en editor configurado (\$EDITOR)
+- [ ] Fuzzy matching en nombres de función/archivo
+
+## Definition of Done
+- Búsqueda por voz retorna resultados en < 1 segundo
+- Jarvis narra los top 3 resultados relevantes"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-11] GitTool — complete git workflow via voice" \
+  --label "epic:tools,priority:high" \
+  --body "## Objetivo
+Workflow completo de git controlado por voz.
+
+## Ejemplos de uso
+\`\`\`
+'hace commit con mensaje agrego autenticación JWT'
+'creá una branch llamada feature/login'
+'mostrá el diff de lo que cambié'
+'hace push y abrí un PR'
+'qué cambié en los últimos 3 commits'
+'quién cambió esta línea'
+\`\`\`
+
+## Tasks
+- [ ] \`core/tools/git_tool.py\` — wrapper con output summarizado
+- [ ] Conventional commits por voz (detecta tipo: feat/fix/refactor/etc.)
+- [ ] Diff summary vocal: 'Modificaste 3 archivos. En main.py agregaste...'
+- [ ] PR creation flow por voz (usa \`gh\` CLI)
+- [ ] Confirmación por voz para operaciones destructivas (reset, force push)
+- [ ] Status summary: 'Tenés 5 archivos modificados y 2 sin trackear'
+- [ ] Git blame por voz: 'quién cambió la función login y cuándo'
+
+## Definition of Done
+- Workflow completo feat-branch → commit → push → PR por voz
+- Operaciones destructivas requieren doble confirmación vocal"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-12] WebFetchTool — fetch URLs and summarize content via voice" \
+  --label "epic:tools,priority:medium" \
+  --body "## Objetivo
+Buscar en la web y resumir documentación por voz.
+
+## Ejemplos de uso
+\`\`\`
+'buscá cómo usar la API de Stripe para pagos recurrentes'
+'abrí la doc de FastAPI y explicame cómo funciona el middleware'
+\`\`\`
+
+## Tasks
+- [ ] \`core/tools/web_fetch_tool.py\`
+- [ ] HTML → text extraction (beautifulsoup4)
+- [ ] Summarización inteligente: solo info relevante para la pregunta
+- [ ] Cache de URLs fetched en la sesión (no re-fetch)
+- [ ] Timeout de 10s con fallback vocal
+
+## Definition of Done
+- URL fetched y resumida en < 5 segundos
+- Jarvis narra solo la sección relevante de la documentación"
+
+# ── EPIC 3: Voice UX ───────────────────────────────────────────────────────
+
+gh issue create --repo $REPO \
+  --title "[EPIC-13] Voice Command Registry — zero-latency command routing" \
+  --label "epic:voice-ux,priority:critical" \
+  --body "## Objetivo
+Mapear frases naturales a acciones SIN pasar por el LLM. Latencia: 0ms adicional.
+
+## Ejemplo de configuración
+\`\`\`python
+VOICE_COMMANDS = {
+    'hace commit': GitTool(action='commit'),
+    'corré los tests': BashTool(cmd='npm test'),
+    'guardá el archivo': FileWriteTool(mode='save'),
+    'deshacé eso': FileEditTool(action='undo'),
+    'mostrá el diff': GitTool(action='diff'),
+    'qué cambié': GitTool(action='status'),
+}
+\`\`\`
+
+## Tasks
+- [ ] \`core/voice/command_registry.py\`
+- [ ] Fuzzy matching para variaciones naturales ('hace un commit', 'hacé commit', 'commit')
+- [ ] Soporte multi-idioma (español/inglés en el mismo registro)
+- [ ] Comandos configurables por usuario en \`~/.jarvis/commands.yaml\`
+- [ ] Fallback a LLM cuando no hay match con confianza suficiente
+- [ ] Métricas: log de qué porcentaje de comandos van al registry vs LLM
+
+## Latency impact
+**CRÍTICO** — elimina llamada API para ~60-70% de comandos frecuentes
+
+## Definition of Done
+- 'hace commit' ejecuta sin llamar a la API
+- Registry customizable por usuario
+- Fallback transparente al LLM cuando no hay match"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-14] Voice Permission System — voice approval for dangerous operations" \
+  --label "epic:voice-ux,priority:critical" \
+  --body "## Objetivo
+Extender el sistema de permisos existente para todas las operaciones de coding.
+
+## Flow
+\`\`\`
+Jarvis: 'Esto va a eliminar 3 archivos permanentemente. ¿Confirmás?'
+Usuario: 'sí, confirmo' | 'no, cancelá' | [silencio 10s → cancela automático]
+\`\`\`
+
+## Clasificación de operaciones
+| Tipo | Acción |
+|------|--------|
+| SAFE | Ejecutar directo (leer, buscar) |
+| REQUIRES_CONFIRM | Pedir 'sí/no' por voz |
+| REQUIRES_EXPLAIN | Explicar qué va a pasar + confirmar |
+
+## Tasks
+- [ ] Extender sistema existente en \`adapters/llm/gemini_summarizer.py\`
+- [ ] Clasificación automática de operaciones por nivel de riesgo
+- [ ] Timeout en prompt de confirmación (10s → cancela)
+- [ ] 'modo experto': reduce confirmaciones para devs avanzados
+- [ ] Log de todas las operaciones confirmadas/canceladas
+
+## Definition of Done
+- Operaciones de escritura/delete siempre piden confirmación vocal
+- Timeout automático cancela operaciones pendientes"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-15] Voice Skill System — reusable voice coding workflows" \
+  --label "epic:voice-ux,priority:high" \
+  --body "## Objetivo
+Skills son flujos de trabajo reutilizables activados por voz. Como los skills de Claude Code pero dictados.
+
+## Ejemplo de skill YAML
+\`\`\`yaml
+name: 'nuevo componente React'
+trigger: 'creá un componente (llamado )?{name}'
+steps:
+  - FileWriteTool: 'src/components/{name}/{name}.tsx'
+  - FileWriteTool: 'src/components/{name}/{name}.test.tsx'
+  - FileWriteTool: 'src/components/{name}/index.ts'
+confirm: true
+announce_completion: true
+\`\`\`
+
+## Built-in skills
+- new-component (React/Vue/Angular)
+- new-api-route (FastAPI/Express/Go)
+- new-test (unit/integration)
+- git-feature-branch (branch → commit → PR)
+- code-review (analiza diff y reporta)
+
+## Tasks
+- [ ] \`core/skills/\` — loader y executor de skills YAML
+- [ ] Variable extraction desde voice input con regex
+- [ ] Skills built-in listos para usar
+- [ ] 'jarvis, enseñame un skill nuevo' — crear skill desde descripción vocal
+- [ ] 'jarvis, qué skills tenés?' → lista los disponibles por voz
+
+## Definition of Done
+- Skill se activa con frase natural
+- Variables extraídas del comando de voz
+- Skills customizables por el usuario"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-16] Streaming TTS pipeline — speak as Claude generates" \
+  --label "epic:voice-ux,priority:critical" \
+  --body "## Objetivo
+Hablar el primer chunk de la respuesta tan pronto como llegue del API, sin esperar la respuesta completa.
+
+## Pipeline objetivo
+\`\`\`
+API chunk → lexer (< 30 chars) → TTS → speaker
+[   ~50ms  ][       < 20ms      ][~0ms ][   ]
+\`\`\`
+
+## Tasks
+- [ ] Modificar \`poc_lexer.py\` para emitir chunks más pequeños (threshold: 30 chars o primer punto)
+- [ ] Eliminar buffers innecesarios entre lexer y TTS
+- [ ] Sentence boundary detection agresivo para TTS inmediato
+- [ ] Config: \`MIN_TTS_CHUNK_CHARS = 30\` (ajustable)
+- [ ] Barge-in sigue funcionando durante streaming
+- [ ] Benchmark: medir latencia actual vs target < 200ms
+
+## Latency impact
+**CRÍTICO** — reduce latencia percibida de 2-3 segundos a < 300ms
+
+## Definition of Done
+- Primera palabra hablada en < 300ms desde fin del speech del usuario
+- Barge-in funciona durante respuesta streaming"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-17] Voice session context announcer" \
+  --label "epic:voice-ux,priority:high" \
+  --body "## Objetivo
+Jarvis sabe y anuncia en qué está trabajando el usuario.
+
+## Startup announcement
+\`\`\`
+'Jarvis listo. Proyecto: my-app. Branch: feature/login.
+Tenés 3 archivos modificados sin commit. ¿En qué arrancamos?'
+\`\`\`
+
+## Tasks
+- [ ] \`core/context/session_context.py\` — estado de la sesión
+- [ ] Anuncio de contexto al inicio de sesión
+- [ ] Auto-detección de proyecto (package.json, pyproject.toml, Cargo.toml)
+- [ ] 'jarvis, en qué estamos?' → resumen vocal del estado actual
+- [ ] Notificaciones proactivas: branch changes, conflictos de merge, CI status
+
+## Definition of Done
+- Startup anuncia proyecto, branch y archivos modificados
+- 'en qué estamos' retorna contexto completo en < 2 segundos"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-18] Barge-in for tool execution — interrupt any running task" \
+  --label "epic:voice-ux,priority:high" \
+  --body "## Objetivo
+Extender el barge-in existente (que interrumpe TTS) para cancelar también tool execution.
+
+## Flow
+\`\`\`
+[Tool ejecutando] → usuario habla → barge-in detectado
+→ cancela tool + TTS
+→ 'Cancelé el comando. ¿Qué querés hacer?'
+\`\`\`
+
+## Tasks
+- [ ] Tool execution como asyncio.Task cancellable
+- [ ] Barge-in signal cancela: tool actual + TTS + pide nueva instrucción
+- [ ] 'jarvis, pará' como comando de cancelación explícito
+- [ ] Cleanup de resources al cancelar (cerrar procesos, archivos abiertos)
+- [ ] Log de cancelaciones para debugging
+
+## Definition of Done
+- Cualquier task en ejecución cancellable diciendo 'pará' o con barge-in
+- Sistema queda en estado limpio después de cancelación"
+
+# ── EPIC 4: Latency ────────────────────────────────────────────────────────
+
+gh issue create --repo $REPO \
+  --title "[EPIC-19] Intent pre-classifier — zero-latency local command routing" \
+  --label "epic:latency,priority:critical" \
+  --body "## Objetivo
+Modelo de clasificación LOCAL (sin API call) que decide el routing en < 50ms.
+
+## Routing decisions
+1. **Registry directo** — comando conocido → ejecución inmediata sin LLM
+2. **Local tool** — operación de sistema simple → ejecutar sin LLM
+3. **Claude API** — razonamiento complejo o code gen necesario
+
+## Tasks
+- [ ] Evaluar modelos: \`mlx-community/phi-3-mini-4k-instruct-mlx\` vs reglas simples
+- [ ] Dataset de entrenamiento: ~300 ejemplos de comandos de voz de coding
+- [ ] Latencia objetivo del classifier: < 50ms en Apple Silicon
+- [ ] Fallback: si confianza < 0.8 → siempre Claude API
+- [ ] Métricas: loguear accuracy del classifier en producción
+- [ ] A/B test: classifier vs sin classifier en latencia end-to-end
+
+## Latency impact
+**CRÍTICO** — elimina API call para comandos simples (~60% de los casos)
+
+## Definition of Done
+- Comandos simples clasificados y ejecutados sin API call
+- Latencia de clasificación < 50ms medida"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-20] Parallel STT + intent detection pipeline" \
+  --label "epic:latency,priority:high" \
+  --body "## Objetivo
+Lanzar clasificación de intento con los primeros tokens de la transcripción en paralelo al STT.
+
+## Pipeline actual (secuencial)
+\`\`\`
+Audio → STT (completo) → Classifier → Tool execution
+[  ~800ms  ]           [ ~50ms    ]
+\`\`\`
+
+## Pipeline objetivo (paralelo)
+\`\`\`
+Audio → STT partial (200ms) → Classifier START
+     → STT complete        → Classifier RESULT → Tool execution
+[  ~800ms total, classifier overlapped       ]
+\`\`\`
+
+## Tasks
+- [ ] MLX Whisper en modo streaming si disponible, sino partial transcription
+- [ ] Classifier recibe partial text y pre-carga el tool probable
+- [ ] Si clasificación parcial correcta → tool ya cargado cuando STT termina
+- [ ] Benchmark: latencia STT finish → tool start antes y después
+- [ ] Fallback: si partial transcript es < 3 palabras → esperar completo
+
+## Latency impact
+**ALTO** — reduce latencia post-STT solapando con STT
+
+## Definition of Done
+- Pipeline paralelo implementado y benchmarkeado
+- Mejora medible en latencia end-to-end"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-21] Response streaming — first token to TTS in < 200ms" \
+  --label "epic:latency,priority:critical" \
+  --body "## Objetivo
+**Target**: Usuario termina de hablar → Jarvis empieza a responder en < 200ms.
+
+## Breakdown de latencia objetivo
+\`\`\`
+STT finish → classifier: 50ms
+Classifier → API first request: 30ms
+API first token: 80ms
+First token → TTS start: 20ms
+TTS → speaker: ~20ms (mac_say)
+───────────────────────────────
+Total: ~200ms
+\`\`\`
+
+## Tasks
+- [ ] Medir latencia actual end-to-end con timestamps en cada etapa
+- [ ] Identificar y eliminar bottlenecks con profiling
+- [ ] Claude API: usar \`anthropic.stream()\` asegurar manejo correcto del primer chunk
+- [ ] TTS: mac_say como default (zero overhead), Edge TTS como fallback
+- [ ] Agregar métricas de latencia al log: P50, P95, P99
+- [ ] Alert si latencia > 500ms de forma consistente
+
+## Definition of Done
+- Latencia medida P50 < 200ms
+- Dashboard de latencia en logs"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-22] Model pre-warming — load all local models at startup" \
+  --label "epic:latency,priority:high" \
+  --body "## Objetivo
+Cargar todos los modelos locales en background al arrancar, no cuando se necesitan por primera vez.
+
+## Tasks
+- [ ] MLX Whisper: pre-cargar en background thread al startup
+- [ ] Intent classifier: pre-cargar en background thread
+- [ ] Warm-up call a Claude API para pre-establecer conexión HTTP/2
+- [ ] Startup time objetivo: < 3 segundos hasta 'Jarvis listo'
+- [ ] Progress indicator vocal durante startup: 'Cargando modelos de voz... listo'
+- [ ] Lazy loading para modelos opcionales (Edge TTS, Kokoro)
+- [ ] Detectar si modelo necesita descarga y avisar por voz
+
+## Definition of Done
+- Cold start < 3 segundos
+- Primera respuesta no tiene latencia adicional por carga de modelo"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-23] Groq fast-path for classification and simple responses" \
+  --label "epic:latency,priority:high" \
+  --body "## Objetivo
+Usar Groq (llama-3.3-70b, ~300ms latencia) para casos donde Claude API (~1s) es overkill.
+
+## Routing rules
+\`\`\`
+Simple task (classify, summarize short) → Groq (~300ms)
+Complex reasoning / code gen            → Claude API (~1s+)
+Ultra-simple (known command)            → Local registry (0ms)
+\`\`\`
+
+## Tasks
+- [ ] Adaptar \`groq_summarizer.py\` para routing inteligente basado en complejidad
+- [ ] Classifier de complejidad: simple / medium / complex
+- [ ] Tool result summarization → siempre Groq (no necesita razonamiento)
+- [ ] Fallback: si Groq falla o rate limit → Claude API
+- [ ] A/B test: calidad de respuesta Groq vs Claude para cada categoría
+
+## Definition of Done
+- Tool results siempre summarizados con Groq
+- Latencia de summarization < 400ms"
+
+# ── EPIC 5: Intelligence ───────────────────────────────────────────────────
+
+gh issue create --repo $REPO \
+  --title "[EPIC-24] Code context awareness — track project state in real-time" \
+  --label "epic:intelligence,priority:high" \
+  --body "## Objetivo
+Jarvis debe saber en todo momento en qué archivo, función y proyecto estás trabajando.
+
+## Context object
+\`\`\`python
+@dataclass
+class CodeContext:
+    project_root: Path
+    language: str          # Python, TypeScript, Go, Rust, etc.
+    framework: str         # FastAPI, React, Express, etc.
+    current_file: Optional[Path]
+    current_function: Optional[str]
+    git_branch: str
+    modified_files: list[Path]
+    recent_errors: list[str]
+    last_test_result: Optional[TestResult]
+\`\`\`
+
+## Tasks
+- [ ] \`core/context/code_context.py\` — detección automática
+- [ ] Watch de filesystem: detectar qué archivo está siendo editado (fsevents en macOS)
+- [ ] Integración con git: branch, modified files, last commit en tiempo real
+- [ ] Contexto inyectado en cada prompt a Claude (sin que el usuario lo pida)
+- [ ] 'jarvis, en qué función estoy?' → respuesta sin API call si hay LSP
+- [ ] Auto-detectar lenguaje y framework del proyecto
+
+## Definition of Done
+- Claude siempre recibe el contexto del proyecto actual
+- 'en qué archivo estamos' se responde sin API call"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-25] Smart output summarization — coding-specific templates" \
+  --label "epic:intelligence,priority:high" \
+  --body "## Objetivo
+Summarizer especializado para cada tipo de output de coding. Nunca raw code en TTS.
+
+## Tipos y templates
+| Tipo | Template vocal |
+|------|---------------|
+| Error | 'Hay un {ErrorType} en línea {N} de {file}. El problema es {causa}' |
+| Tests | 'Pasaron {N} de {total} tests. Los que fallaron son: {list}' |
+| Build | 'Build exitoso en {time}. Bundle: {size}' |
+| Git log | 'Los últimos {N} commits: {summary}' |
+| Diff | 'Modificaste {N} archivos. Los cambios principales son: {summary}' |
+| Stack trace | 'La excepción ocurrió en {function} ({file}:{line})' |
+
+## Tasks
+- [ ] \`core/summarizers/coding_summarizer.py\`
+- [ ] Detectar tipo de output automáticamente
+- [ ] Template por tipo con info mínima y relevante
+- [ ] NUNCA leer stack traces completos — extraer línea relevante
+- [ ] NUNCA leer código — siempre explicar en lenguaje natural
+
+## Definition of Done
+- Cualquier output de coding resumido en < 3 oraciones
+- Sin raw code, sin stack traces completas en TTS"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-26] Error pattern detection and proactive voice alert" \
+  --label "epic:intelligence,priority:medium" \
+  --body "## Objetivo
+Detectar errores en el output de tools y alertar proactivamente sin que el usuario pregunte.
+
+## Clasificación de severidad
+\`\`\`
+WARNING  → mencionar al final: 'Por cierto, hubo un warning en...'
+ERROR    → interrumpir y explicar: 'Hay un error. {explicación}'
+CRITICAL → pedir atención inmediata: 'STOP. Esto falló de forma crítica'
+\`\`\`
+
+## Tasks
+- [ ] Watcher de output: detectar patterns (stderr, exit codes != 0, 'Error:', 'Exception:')
+- [ ] Alert vocal sin esperar que el usuario pregunte
+- [ ] Clasificar severidad automáticamente
+- [ ] Sugerir fix conocido cuando el error matchea un pattern conocido
+- [ ] 'jarvis, ignorá los warnings' → modo quiet para warnings
+
+## Definition of Done
+- Errores detectados y narrados en < 500ms de aparecer en el output
+- Sugerencias de fix para errores comunes"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-27] Test result narrator — voice-friendly test output" \
+  --label "epic:intelligence,priority:medium" \
+  --body "## Objetivo
+Transformar output de test runners en resúmenes vocales concisos.
+
+## Ejemplo
+\`\`\`
+Usuario: 'corré los tests'
+Jarvis: 'Corrí 50 tests en 3.2 segundos. Pasaron 48, fallaron 2.
+         El primer fallo está en UserService, test de login:
+         esperaba status 200 pero recibió 401.
+         ¿Querés que lo analice?'
+\`\`\`
+
+## Soportar frameworks
+- JavaScript: Jest, Vitest, Mocha
+- Python: pytest, unittest
+- Go: go test
+- Rust: cargo test
+
+## Tasks
+- [ ] Parsers por framework para extraer: total, passed, failed, time
+- [ ] Para failures: test name + error message (SIN stack trace)
+- [ ] 'revisá el primer error' → FileReadTool + análisis de la línea fallida
+- [ ] Soporte para test watch mode: narrar solo cuando hay cambios en resultados
+
+## Definition of Done
+- Test results narrados en < 3 oraciones
+- Failures explicados sin stack trace completa"
+
+# ── EPIC 6: Advanced ──────────────────────────────────────────────────────
+
+gh issue create --repo $REPO \
+  --title "[EPIC-28] Multi-agent voice orchestration" \
+  --label "epic:advanced,priority:medium" \
+  --body "## Objetivo
+Lanzar múltiples sub-agentes en paralelo vía voz.
+
+## Ejemplo
+\`\`\`
+Usuario: 'mientras escribís los tests, buscá si hay una librería mejor para esto'
+Jarvis: 'Arrancando dos agentes. El primero escribe tests, el segundo investiga librerías.'
+[... tiempo después ...]
+Jarvis: 'El agente de tests terminó. El de investigación todavía trabaja...'
+\`\`\`
+
+## Tasks
+- [ ] \`core/agents/\` — sub-agent spawning con asyncio
+- [ ] Cada agente tiene su propio tool context y conversación
+- [ ] Orquestador vocal: reporta progreso de múltiples agentes
+- [ ] Cancelación por voz de agentes individuales: 'cancelá el agente de tests'
+- [ ] Resultados narrados en orden de finalización
+
+## Definition of Done
+- Dos agentes paralelos lanzados y monitoreados por voz
+- Cancelación individual funciona"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-29] MCP server integration via voice" \
+  --label "epic:advanced,priority:medium" \
+  --body "## Objetivo
+Conectar MCP servers como extensiones de los tools de Jarvis, activables por voz.
+
+## Ejemplo
+\`\`\`
+Usuario: 'mostrá los tickets del sprint en Linear'
+Usuario: 'cerrá el ticket LIN-123 como done'
+Usuario: 'conectate al servidor de Postgres y mostrá los usuarios activos'
+\`\`\`
+
+## Tasks
+- [ ] \`core/mcp/\` — MCP client (Python MCP SDK)
+- [ ] Config de MCP servers en \`~/.jarvis/mcp.yaml\`
+- [ ] Auto-discovery de tools disponibles en cada server
+- [ ] Voice triggers para MCP tools (auto-generados desde la descripción del tool)
+- [ ] Jarvis como MCP server: exponer tools a Claude Code CLI
+
+## Definition of Done
+- MCP server configurado en YAML disponible por voz
+- Tool discovery automático"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-30] Session memory and resume — cross-session context" \
+  --label "epic:advanced,priority:medium" \
+  --body "## Objetivo
+Jarvis recuerda lo que hiciste en sesiones anteriores.
+
+## Ejemplo
+\`\`\`
+Usuario: 'jarvis, ¿qué estábamos haciendo ayer?'
+Jarvis: 'Estabas implementando autenticación JWT. Terminaste el middleware
+         pero te faltaba el refresh token endpoint. ¿Seguimos?'
+\`\`\`
+
+## Tasks
+- [ ] \`core/memory/\` — persistencia de sesión en \`~/.jarvis/sessions/\`
+- [ ] Session summary al cerrar: qué se hizo, qué falta, archivos modificados
+- [ ] Resume: 'jarvis, continuá donde estábamos'
+- [ ] Memory search por voz: 'cómo resolvimos el problema de CORS la semana pasada'
+- [ ] Integración con Engram si está disponible
+- [ ] Limpieza automática de sesiones viejas (> 30 días)
+
+## Definition of Done
+- 'qué hicimos ayer' retorna contexto de la sesión anterior
+- Resume arranca exactamente donde se quedó"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-31] LSP integration — code intelligence via voice" \
+  --label "epic:advanced,priority:low" \
+  --body "## Objetivo
+Language Server Protocol para code intelligence sin necesitar abrir un editor.
+
+## Ejemplos de uso
+\`\`\`
+'andá a la definición de authenticate'
+'dónde se usa la función createUser'
+'qué parámetros acepta esta función'
+\`\`\`
+
+## Tasks
+- [ ] \`core/lsp/\` — LSP client (python-lsp-jsonrpc o similar)
+- [ ] Go-to-definition por voz → abre archivo en \$EDITOR
+- [ ] Find references → narra los top 3 lugares donde se usa
+- [ ] Hover info → narra la signature y docstring de la función
+- [ ] Auto-detectar LSP server según lenguaje (pylsp, typescript-language-server, etc.)
+- [ ] Fallback: si no hay LSP → ripgrep para find references
+
+## Definition of Done
+- Go-to-definition funciona por voz
+- Find references narra los resultados"
+
+gh issue create --repo $REPO \
+  --title "[EPIC-32] Claude Code CLI as PTY backend (hybrid mode)" \
+  --label "epic:advanced,priority:low" \
+  --body "## Objetivo
+Modo híbrido donde Jarvis wrappea el Claude Code CLI para máxima compatibilidad, con control por voz.
+
+## Use case
+Usuario que quiere la experiencia completa de Claude Code + control 100% por voz.
+
+## Tasks
+- [ ] PTY adapter para Claude Code CLI (adaptar el existente de Gemini CLI)
+- [ ] Patch del lexer para el output format de Claude Code (distinto a Gemini)
+- [ ] Tool calls de Claude Code interceptados y anunciados por voz
+- [ ] Permission prompts de Claude Code → voice approval gate
+- [ ] Modo de selección: \`jarvis --mode pty --cli claude-code\`
+- [ ] Detectar instalación de Claude Code CLI en el sistema
+
+## Definition of Done
+- Claude Code CLI wrapeado y controlado 100% por voz
+- Permission prompts resueltos por voz sin tocar el teclado"
+
+echo ""
+echo "✅ Todas las issues creadas en https://github.com/$REPO/issues"
+echo "📋 Próximo paso: asignar issues a milestones en GitHub"

--- a/docs/ROADMAP_VOICE_CLI.md
+++ b/docs/ROADMAP_VOICE_CLI.md
@@ -1,0 +1,672 @@
+# JARVIS — Voice-First Programming CLI: Complete Roadmap
+
+## Vision
+
+Transform Jarvis from a PTY wrapper around Gemini CLI into a **standalone voice-first CLI for programming** — powered by Claude API, with its own tool system, skill registry, and a latency-first architecture.
+
+The user speaks. Jarvis acts. Latency is the enemy. Every millisecond matters.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                    JARVIS VOICE CODING CLI                       │
+│                                                                  │
+│  [Wake Word]                                                     │
+│      ↓                                                           │
+│  [VAD + MLX Whisper STT] ←── barge-in thread                   │
+│      ↓                                                           │
+│  [Intent Pre-classifier]  ←── local model, no API call          │
+│      ↓                                                           │
+│  ┌───┴──────────────────────────────────┐                        │
+│  ↓                                      ↓                        │
+│  [Local Executor]              [Claude API (streaming)]          │
+│  (git, file ops, search,       (complex reasoning,               │
+│   shell commands)               code gen, analysis)              │
+│  ↓                                      ↓                        │
+│  └───────────────────┬──────────────────┘                        │
+│                      ↓                                           │
+│             [Voice Summarizer]  ←── never reads raw code         │
+│                      ↓                                           │
+│             [Streaming TTS]     ←── first token → speaker        │
+│                      ↓                                           │
+│                  [User hears]                                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Milestones
+
+| # | Name | Goal |
+|---|------|------|
+| M1 | Foundation | Jarvis como CLI standalone con Claude API |
+| M2 | Tool System | Herramientas de coding adaptadas para voz |
+| M3 | Voice UX | UX de voz específico para programar |
+| M4 | Latency Zero | Optimizaciones de latencia agresivas |
+| M5 | Intelligence | Conciencia de contexto de código |
+| M6 | Advanced | Multi-agente, MCP, LSP |
+
+---
+
+## Issues
+
+### EPIC 1 — Foundation: Standalone CLI
+
+#### Issue 1: Refactor entry point as standalone `jarvis` CLI
+**Labels**: `epic:foundation`, `priority:critical`
+
+Jarvis debe ser instalable como comando global (`pip install -e .` o similar).
+
+**Tasks:**
+- [ ] Crear `pyproject.toml` con entry point `jarvis = main:cli`
+- [ ] Refactorizar `main.py` para soportar subcomandos: `jarvis start`, `jarvis config`, `jarvis doctor`
+- [ ] Agregar `--backend` flag: `claude` | `gemini` | `groq`
+- [ ] Help text por voz ("jarvis help" habla los comandos disponibles)
+- [ ] Validación de env vars al startup con mensajes de error claros
+
+**Latency impact**: ninguno (infraestructura)
+
+---
+
+#### Issue 2: Claude API direct integration
+**Labels**: `epic:foundation`, `priority:critical`
+
+Reemplazar el PTY wrapper de Gemini CLI con llamadas directas a la Claude API con streaming. El PTY queda como fallback cuando el usuario quiere wrappear un CLI externo.
+
+**Tasks:**
+- [ ] Crear `adapters/llm/claude_api_adapter.py` — streaming con `anthropic` SDK
+- [ ] Implementar streaming response handler (chunks → lexer existente)
+- [ ] Adaptar `poc_lexer.py` para manejar response de API (no PTY output)
+- [ ] Tool use loop: detectar tool calls en el stream, ejecutar, enviar result
+- [ ] Mantener historial de conversación en memoria
+- [ ] Configurar model: `claude-opus-4-6` para razonamiento, `claude-haiku-4-5` para clasificación rápida
+
+**Latency impact**: ALTO — streaming desde primer token, TTS empieza antes de que termine la respuesta
+
+---
+
+#### Issue 3: Multi-backend CLI adapter (Claude + Gemini + PTY mode)
+**Labels**: `epic:foundation`, `priority:high`
+
+El sistema de adapters ya existe para TTS/STT/LLM. Extender para soportar tres modos de operación:
+
+```
+MODE=api       → llama directamente Claude/Gemini API (mínima latencia)
+MODE=pty       → wrappea un CLI externo (Claude Code CLI, Gemini CLI)
+MODE=hybrid    → API para reasoning, PTY para tool execution
+```
+
+**Tasks:**
+- [ ] Crear `core/backend/` con `BackendBase`, `APIBackend`, `PTYBackend`
+- [ ] Factory pattern seleccionable via `JARVIS_MODE` env var
+- [ ] Unificar interfaz: ambos backends emiten eventos al mismo lexer/TTS pipeline
+- [ ] Tests de smoke para cada modo
+
+---
+
+#### Issue 4: Configuration system
+**Labels**: `epic:foundation`, `priority:high`
+
+Sistema de configuración unificado (YAML + env vars + voice commands).
+
+**Tasks:**
+- [ ] `~/.jarvis/config.yaml` como config persistente
+- [ ] Schema validado con `pydantic` 
+- [ ] Voice config: "jarvis, cambiá la voz a Alloy", "jarvis, usá Groq para clasificación"
+- [ ] Hot reload de config sin reiniciar
+- [ ] `jarvis doctor` que verifica config, APIs, audio devices, modelos descargados
+
+---
+
+### EPIC 2 — Tool System
+
+#### Issue 5: Tool registry — pluggable tool system
+**Labels**: `epic:tools`, `priority:critical`
+
+Base para todos los tools. Inspirado en Claude Code pero adaptado para voz.
+
+```python
+class VoiceTool:
+    name: str
+    description: str          # Lo que le pasamos a Claude
+    voice_triggers: list[str] # Frases naturales que activan este tool
+    requires_confirmation: bool
+    
+    async def execute(self, params: dict) -> ToolResult
+    def summarize_result(self, result: ToolResult) -> str  # Para TTS
+```
+
+**Tasks:**
+- [ ] Crear `core/tools/base.py` con `VoiceTool` base class
+- [ ] Crear `core/tools/registry.py` — registro y descubrimiento de tools
+- [ ] Tool result → TTS summarizer pipeline
+- [ ] Tool execution con timeout y error handling
+- [ ] Logging de tool calls para debugging
+
+---
+
+#### Issue 6: BashTool — execute shell commands via voice
+**Labels**: `epic:tools`, `priority:high`
+
+```
+Usuario: "corré npm test"
+Usuario: "instalá la dependencia axios"
+Usuario: "mostrá el log de docker"
+```
+
+**Tasks:**
+- [ ] `core/tools/bash_tool.py` con subprocess + streaming output
+- [ ] Safety gate: lista de comandos peligrosos requieren confirmación por voz
+- [ ] Output streaming → lexer → TTS (el usuario escucha el output en tiempo real)
+- [ ] Timeout configurable
+- [ ] Working directory awareness (sabe en qué directorio estás)
+- [ ] Comandos interactivos: detectar prompts y preguntar al usuario
+
+**Latency impact**: streaming de output — el usuario escucha el output mientras se ejecuta
+
+---
+
+#### Issue 7: FileReadTool — read and summarize files via voice
+**Labels**: `epic:tools`, `priority:high`
+
+```
+Usuario: "leé el archivo main.py"
+Usuario: "explicame qué hace el archivo de configuración"
+Usuario: "mostrá las primeras 50 líneas de app.ts"
+```
+
+**Tasks:**
+- [ ] `core/tools/file_read_tool.py`
+- [ ] Nunca leer el archivo completo en voz — siempre resumir con LLM
+- [ ] Para archivos grandes: chunking inteligente, resumir sección relevante
+- [ ] Soporte para imágenes (descripción por voz), PDFs (summary), código (explain)
+- [ ] "leé el archivo" → Claude lo lee y explica en lenguaje natural
+
+---
+
+#### Issue 8: FileWriteTool — create files via voice dictation
+**Labels**: `epic:tools`, `priority:high`
+
+```
+Usuario: "creá un archivo llamado utils.py con una función que convierte celsius a fahrenheit"
+Usuario: "creá el archivo README con lo que acabamos de hacer"
+```
+
+**Tasks:**
+- [ ] `core/tools/file_write_tool.py`
+- [ ] Confirmación por voz antes de escribir ("¿Confirmo que creo utils.py?")
+- [ ] Preview verbal del contenido antes de escribir
+- [ ] Soporte para templates ("creá un componente React llamado Button")
+
+---
+
+#### Issue 9: FileEditTool — edit files via voice description
+**Labels**: `epic:tools`, `priority:high`
+
+```
+Usuario: "en main.py, cambiá la función login para que use JWT"
+Usuario: "agregá validación de email a la función register"
+Usuario: "refactorizá el for loop en línea 45 para usar list comprehension"
+```
+
+**Tasks:**
+- [ ] `core/tools/file_edit_tool.py`
+- [ ] Claude genera el diff, Jarvis lo aplica
+- [ ] Confirmación verbal del cambio propuesto antes de aplicar
+- [ ] Undo por voz: "deshacé el último cambio"
+- [ ] Diff summary por voz antes y después
+
+---
+
+#### Issue 10: SearchTool — voice code search (grep + glob)
+**Labels**: `epic:tools`, `priority:high`
+
+```
+Usuario: "buscá dónde se usa la función authenticate"
+Usuario: "encontrá todos los archivos TypeScript con useEffect"
+Usuario: "buscá TODO comments en el proyecto"
+```
+
+**Tasks:**
+- [ ] `core/tools/search_tool.py` con ripgrep (`rg`) bajo el capó
+- [ ] Glob para file patterns, Grep para content search
+- [ ] Resultados resumidos por voz: "Encontré 5 archivos. El más relevante es..."
+- [ ] "andá al resultado 1" → abre el archivo en el editor configurado
+
+---
+
+#### Issue 11: GitTool — complete git workflow via voice
+**Labels**: `epic:tools`, `priority:high`
+
+```
+Usuario: "hace commit con el mensaje 'agrego autenticación JWT'"
+Usuario: "creá una branch llamada feature/login"
+Usuario: "mostrá el diff de lo que cambié"
+Usuario: "hace push y abrí un PR"
+Usuario: "qué cambié en los últimos 3 commits"
+```
+
+**Tasks:**
+- [ ] `core/tools/git_tool.py` — wrapper de git con output summarizado
+- [ ] Conventional commits por voz
+- [ ] Diff summary vocal: "Modificaste 3 archivos. En main.py agregaste..."
+- [ ] PR creation flow por voz (requiere `gh` CLI)
+- [ ] Confirmación por voz para operaciones destructivas (reset, force push)
+- [ ] Status summary: "Tenés 5 archivos modificados y 2 sin trackear"
+
+---
+
+#### Issue 12: WebFetchTool — fetch URLs and summarize content
+**Labels**: `epic:tools`, `priority:medium`
+
+```
+Usuario: "buscá cómo usar la API de Stripe para pagos recurrentes"
+Usuario: "abrí la documentación de FastAPI y explicame cómo funciona el middleware"
+```
+
+**Tasks:**
+- [ ] `core/tools/web_fetch_tool.py`
+- [ ] HTML → text extraction (beautifulsoup4)
+- [ ] Summarización inteligente: solo la info relevante en voz
+- [ ] Cache de URLs fetched en la sesión
+
+---
+
+### EPIC 3 — Voice UX
+
+#### Issue 13: Voice Command Registry — natural language to action mapping
+**Labels**: `epic:voice-ux`, `priority:critical`
+
+Sistema que mapea frases naturales a herramientas sin pasar por el LLM (zero-latency para comandos conocidos).
+
+```python
+VOICE_COMMANDS = {
+    "hace commit": GitTool(action="commit"),
+    "corré los tests": BashTool(cmd="npm test"),
+    "guardá el archivo": FileWriteTool(mode="save"),
+    "deshacé eso": FileEditTool(action="undo"),
+    "mostrá el diff": GitTool(action="diff"),
+}
+```
+
+**Tasks:**
+- [ ] `core/voice/command_registry.py`
+- [ ] Fuzzy matching para variaciones naturales del idioma
+- [ ] Soporte multi-idioma (español/inglés)
+- [ ] Comandos configurables por usuario en `~/.jarvis/commands.yaml`
+- [ ] Fallback a LLM cuando no hay match en el registro
+
+**Latency impact**: CRÍTICO — comandos conocidos se ejecutan sin llamada a la API
+
+---
+
+#### Issue 14: Voice Permission System — approval for dangerous operations
+**Labels**: `epic:voice-ux`, `priority:critical`
+
+Extensión del sistema existente para cubrir todas las operaciones de coding.
+
+```
+Jarvis: "Esto va a eliminar 3 archivos permanentemente. ¿Confirmás?"
+Usuario: "sí, confirmo" | "no, cancelá"
+```
+
+**Tasks:**
+- [ ] Extender `adapters/llm/gemini_summarizer.py` para operations de coding
+- [ ] Clasificar operaciones: SAFE | REQUIRES_CONFIRM | REQUIRES_EXPLAIN
+- [ ] Timeout en el prompt de confirmación (default: 10s → cancela)
+- [ ] "modo experto" que reduce confirmaciones para usuarios avanzados
+- [ ] Log de operaciones confirmadas/canceladas
+
+---
+
+#### Issue 15: Voice Skill System — reusable voice workflows
+**Labels**: `epic:voice-ux`, `priority:high`
+
+Skills son flujos de trabajo reutilizables activados por voz. Inspirado en Claude Code skills.
+
+```yaml
+# ~/.jarvis/skills/new-component.yaml
+name: "nuevo componente React"
+trigger: "creá un componente (llamado )?{name}"
+steps:
+  - FileWriteTool: "src/components/{name}/{name}.tsx"
+  - FileWriteTool: "src/components/{name}/{name}.test.tsx"
+  - FileWriteTool: "src/components/{name}/index.ts"
+confirm: true
+```
+
+**Tasks:**
+- [ ] `core/skills/` — loader y executor de skills YAML
+- [ ] Variable extraction desde voice input (nombre del componente, etc.)
+- [ ] Skills built-in: new-component, new-api-route, new-test, git-feature-branch
+- [ ] "jarvis, enseñame un skill nuevo" — crea skill desde descripción vocal
+- [ ] Skill discovery: "jarvis, qué skills tenés?"
+
+---
+
+#### Issue 16: Streaming TTS pipeline — speak as Claude generates
+**Labels**: `epic:voice-ux`, `priority:critical`
+
+El sistema actual espera a que el lexer acumule una oración completa. Optimizar para hablar el primer chunk tan pronto como llegue del API.
+
+**Tasks:**
+- [ ] Modificar `poc_lexer.py` para emitir chunks más pequeños (< 50ms acumulación)
+- [ ] Pipeline: API chunk → lexer → TTS sin buffering innecesario
+- [ ] Sentence boundary detection más agresivo para TTS inmediato
+- [ ] Adjustable chunk size via config: `MIN_TTS_CHUNK_CHARS = 30`
+- [ ] Barge-in sigue funcionando durante streaming
+
+**Latency impact**: CRÍTICO — reduce latencia percibida de segundos a milliseconds
+
+---
+
+#### Issue 17: Voice session context — "estás trabajando en X"
+**Labels**: `epic:voice-ux`, `priority:high`
+
+Jarvis debe anunciar el contexto de la sesión y mantenerlo actualizado.
+
+```
+Startup: "Jarvis listo. Proyecto: my-app. Branch: feature/login. 
+          Tenés 3 archivos modificados sin commit."
+```
+
+**Tasks:**
+- [ ] `core/context/session_context.py` — rastrea proyecto, branch, archivos abiertos
+- [ ] Anuncio de contexto al inicio de sesión
+- [ ] Auto-detección de proyecto (package.json, pyproject.toml, Cargo.toml, etc.)
+- [ ] "jarvis, en qué estamos?" → resumen vocal del estado actual
+- [ ] Notificación vocal cuando hay cambios de branch, conflictos, etc.
+
+---
+
+#### Issue 18: Barge-in for tool execution — interrupt any running task
+**Labels**: `epic:voice-ux`, `priority:high`
+
+El barge-in actual interrumpe el TTS. Extender para interrumpir tool execution.
+
+**Tasks:**
+- [ ] Tool execution en proceso cancellable (asyncio.Task con CancelledError)
+- [ ] Barge-in signal → cancela tool + TTS + pregunta qué hacer
+- [ ] "jarvis, pará" → cancela todo inmediatamente
+- [ ] Confirmación verbal de cancelación: "Cancelé el comando. ¿Qué querés hacer?"
+
+---
+
+### EPIC 4 — Latency Zero
+
+#### Issue 19: Intent pre-classifier — zero-latency command routing
+**Labels**: `epic:latency`, `priority:critical`
+
+Clasificador local (sin API call) que decide si el comando va a:
+1. **Registry directo** — comando conocido, ejecución inmediata
+2. **Claude API** — razonamiento complejo necesario
+3. **Local tool** — operación de sistema directa
+
+**Tasks:**
+- [ ] Modelo de clasificación local: `mlx-community/phi-3-mini-4k-instruct-mlx` o similar
+- [ ] Entrenado/finetuned en ~200 ejemplos de comandos de voz de programación
+- [ ] Latencia objetivo: < 50ms para clasificación
+- [ ] Fallback: si el clasificador tiene baja confianza → siempre Claude API
+- [ ] Métricas: loguear accuracy del clasificador en producción
+
+**Latency impact**: CRÍTICO — elimina llamada API para ~70% de comandos
+
+---
+
+#### Issue 20: Parallel STT + classification pipeline
+**Labels**: `epic:latency`, `priority:high`
+
+Mientras el STT transcribe, lanzar el clasificador en paralelo con los primeros tokens.
+
+**Tasks:**
+- [ ] Streaming STT: MLX Whisper en modo streaming (si soportado)
+- [ ] Clasificación parcial con primeros N tokens de la transcripción
+- [ ] Pipeline: audio chunk → STT partial → classifier → pre-load tool
+- [ ] Benchmark antes/después: medir latencia end-to-end
+
+**Latency impact**: ALTO — overlapping STT y clasificación
+
+---
+
+#### Issue 21: Response streaming — first token to TTS in < 200ms
+**Labels**: `epic:latency`, `priority:critical`
+
+**Target**: Usuario termina de hablar → Jarvis empieza a responder en < 200ms.
+
+**Tasks:**
+- [ ] Medir latencia actual end-to-end (STT finish → TTS start)
+- [ ] Identificar y eliminar bottlenecks en el pipeline
+- [ ] Claude API: usar `anthropic.stream()` con manejo de primer chunk
+- [ ] TTS: mac_say como default (zero overhead), Edge TTS como fallback
+- [ ] Benchmark continuo: alert si latencia > 500ms
+
+**Latency impact**: CRÍTICO — latencia percibida es lo que mide el usuario
+
+---
+
+#### Issue 22: Model pre-warming at startup
+**Labels**: `epic:latency`, `priority:high`
+
+Cargar todos los modelos locales al arrancar, no cuando se necesitan.
+
+**Tasks:**
+- [ ] MLX Whisper: pre-cargar al startup
+- [ ] Intent classifier: pre-cargar al startup  
+- [ ] Warm-up call a Claude API para pre-establecer conexión HTTP/2
+- [ ] Startup time objetivo: < 3 segundos
+- [ ] Progress indicator vocal durante startup: "Cargando modelos..."
+- [ ] Lazy loading para modelos opcionales (Edge TTS, Kokoro, etc.)
+
+---
+
+#### Issue 23: Groq fast-path for classification and simple responses
+**Labels**: `epic:latency`, `priority:high`
+
+Groq (llama-3.3-70b) tiene ~300ms de latencia vs ~1s de Claude. Usarlo para:
+- Clasificación de intento cuando el local model no es suficiente
+- Respuestas simples que no requieren razonamiento profundo
+- Resúmenes rápidos de tool results
+
+**Tasks:**
+- [ ] Adaptar `groq_summarizer.py` para routing inteligente
+- [ ] Reglas de routing: simple/fast → Groq, complex/code → Claude
+- [ ] A/B testing de respuestas Groq vs Claude para optimizar routing
+- [ ] Fallback: si Groq falla → Claude API
+
+---
+
+### EPIC 5 — Intelligence
+
+#### Issue 24: Code context awareness — track project state
+**Labels**: `epic:intelligence`, `priority:high`
+
+Jarvis debe saber en todo momento en qué estás trabajando.
+
+```python
+@dataclass
+class CodeContext:
+    project_root: Path
+    language: str          # Python, TypeScript, Go, etc.
+    framework: str         # FastAPI, React, etc.
+    current_file: Path
+    current_function: str
+    git_branch: str
+    modified_files: list[Path]
+    recent_errors: list[str]
+```
+
+**Tasks:**
+- [ ] `core/context/code_context.py` — detección automática de contexto
+- [ ] Watch de filesystem: detectar qué archivo está siendo editado
+- [ ] Integración con git: branch, modified files, last commit
+- [ ] Contexto inyectado automáticamente en cada prompt a Claude
+- [ ] "jarvis, en qué función estoy?" → respuesta inmediata sin API call
+
+---
+
+#### Issue 25: Smart output summarization — coding-specific
+**Labels**: `epic:intelligence`, `priority:high`
+
+El summarizer actual es genérico. Crear uno específico para output de coding.
+
+**Tasks:**
+- [ ] Detectar tipo de output: error, test result, build output, git log, etc.
+- [ ] Template de summarización por tipo:
+  - Error: "Hay un TypeError en línea 45 de auth.py. El problema es..."
+  - Tests: "Pasaron 47 de 50 tests. Los 3 que fallaron son..."
+  - Build: "Build exitoso en 2.3 segundos. Bundle size: 450KB"
+  - Git log: "Los últimos 3 commits agregan autenticación, tests y documentación"
+- [ ] Nunca leer stack traces completos — extraer la línea relevante
+
+---
+
+#### Issue 26: Error pattern detection and voice alert
+**Labels**: `epic:intelligence`, `priority:medium`
+
+Detectar errores en el output de herramientas y alertar proactivamente.
+
+**Tasks:**
+- [ ] Watcher de output: detectar patterns de error (stderr, exit codes, "Error:", "Exception:")
+- [ ] Alert vocal inmediato sin esperar que el usuario pregunte
+- [ ] Clasificar severidad: WARNING (mencionar), ERROR (interrumpir y explicar), CRITICAL (pedir confirmación)
+- [ ] Sugerir fix automáticamente cuando hay un error conocido
+
+---
+
+#### Issue 27: Test result summarization — voice-friendly
+**Labels**: `epic:intelligence`, `priority:medium`
+
+```
+Usuario: "corré los tests"
+Jarvis: "Corrí 50 tests en 3.2 segundos. Pasaron 48, fallaron 2. 
+         El primer error está en UserService en el test de login: 
+         esperaba 200 pero recibió 401. ¿Querés que lo revise?"
+```
+
+**Tasks:**
+- [ ] Parsers para Jest, pytest, Go test, Cargo test
+- [ ] Summary template: N passed, M failed, tiempo total
+- [ ] Para failures: extraer test name + error message (no stack trace)
+- [ ] "revisá el primer error" → FileReadTool + análisis de la línea fallida
+
+---
+
+### EPIC 6 — Advanced
+
+#### Issue 28: Multi-agent voice orchestration
+**Labels**: `epic:advanced`, `priority:medium`
+
+```
+Usuario: "mientras escribís los tests, buscá si hay una librería mejor para esto"
+```
+
+Lanzar sub-agentes en paralelo via voz.
+
+**Tasks:**
+- [ ] `core/agents/` — sub-agent spawning
+- [ ] Cada agente tiene su propio tool context y conversación
+- [ ] Orquestador vocal: reporta progreso de múltiples agentes
+- [ ] "agente 1: terminó. Agente 2: todavía trabajando..."
+- [ ] Cancelación por voz de agentes individuales
+
+---
+
+#### Issue 29: MCP server integration via voice
+**Labels**: `epic:advanced`, `priority:medium`
+
+Soportar MCP servers como extensiones de los tools de Jarvis.
+
+```
+Usuario: "conectate al servidor de Linear y mostrá los tickets del sprint"
+```
+
+**Tasks:**
+- [ ] `core/mcp/` — MCP client implementation (SDK Python)
+- [ ] Configuración de MCP servers en `~/.jarvis/mcp.yaml`
+- [ ] Auto-discovery de tools disponibles en cada MCP server
+- [ ] Voice triggers para MCP tools
+- [ ] Jarvis como MCP server (exponerse a Claude Code CLI)
+
+---
+
+#### Issue 30: Session memory and resume
+**Labels**: `epic:advanced`, `priority:medium`
+
+```
+Usuario: "jarvis, ¿qué estábamos haciendo ayer?"
+Jarvis: "Estabas implementando autenticación JWT. Terminaste el middleware 
+         pero te faltaba el refresh token. ¿Seguimos?"
+```
+
+**Tasks:**
+- [ ] `core/memory/` — persistencia de conversación entre sesiones
+- [ ] Session summary al cerrar (qué se hizo, qué falta)
+- [ ] Resume: "jarvis, continuá donde estábamos"
+- [ ] Memory search: "jarvis, cómo resolvimos el problema de CORS la semana pasada"
+- [ ] Integración con Engram (sistema de memoria del orquestador)
+
+---
+
+#### Issue 31: LSP integration for code intelligence
+**Labels**: `epic:advanced`, `priority:low`
+
+Language Server Protocol para code intelligence sin abrir un editor.
+
+**Tasks:**
+- [ ] `core/lsp/` — LSP client (python-lsp-jsonrpc o similar)
+- [ ] Go-to-definition por voz: "andá a la definición de authenticate"
+- [ ] Find references: "dónde se usa esta función"
+- [ ] Hover info: "qué hace este método"
+- [ ] Auto-detectar LSP server según lenguaje del proyecto
+
+---
+
+#### Issue 32: Claude Code CLI as PTY backend (hybrid mode)
+**Labels**: `epic:advanced`, `priority:low`
+
+Modo híbrido donde Jarvis wrappea el Claude Code CLI en lugar de llamar a la API directamente. Para usuarios que quieren la experiencia completa de Claude Code + control por voz.
+
+**Tasks:**
+- [ ] PTY adapter para Claude Code CLI (ya existe para Gemini CLI — adaptar)
+- [ ] Patch del lexer para el output format de Claude Code
+- [ ] Tool calls de Claude Code interceptados y anunciados por voz
+- [ ] Confirmaciones de permisos de Claude Code → voice approval
+- [ ] Modo de selección: `jarvis --mode pty --cli claude-code`
+
+---
+
+## Priority Matrix
+
+| Priority | Issues |
+|----------|--------|
+| 🔴 Critical | #1, #2, #5, #13, #16, #19, #21 |
+| 🟠 High | #3, #4, #6, #7, #8, #9, #10, #11, #14, #15, #17, #18, #20, #22, #23, #24, #25 |
+| 🟡 Medium | #12, #26, #27, #28, #29, #30 |
+| 🟢 Low | #31, #32 |
+
+## Sprint 1 (MVP Voice Coding CLI)
+
+Issues: #1, #2, #5, #6, #11, #13, #16, #21
+
+**Goal**: Jarvis habla con Claude API, puede ejecutar shell commands y git, y la latencia es mínima.
+
+## Sprint 2 (Tool System Complete)
+
+Issues: #3, #4, #7, #8, #9, #10, #14, #15, #19
+
+**Goal**: Todas las herramientas de coding básicas disponibles por voz.
+
+## Sprint 3 (Intelligence + Latency)
+
+Issues: #17, #18, #20, #22, #23, #24, #25, #26, #27
+
+**Goal**: Jarvis entiende el contexto del código y responde en < 200ms.
+
+## Sprint 4 (Advanced)
+
+Issues: #28, #29, #30, #31, #32
+
+**Goal**: Multi-agente, MCP, memoria persistente, LSP.

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,0 +1,3 @@
+"""J.A.R.V.I.S. — Just A Rather Very Intelligent System"""
+
+__version__ = "0.1.0"

--- a/jarvis/__main__.py
+++ b/jarvis/__main__.py
@@ -1,0 +1,3 @@
+from jarvis.cli import main
+
+main()

--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -465,5 +465,35 @@ def show_config() -> None:
     )
 
 
+# ─── jarvis desktop ───────────────────────────────────────────────────────────
+
+@main.command("desktop")
+def desktop_mode() -> None:
+    """
+    Lanza J.A.R.V.I.S como app de escritorio (system tray).
+
+    \b
+    No requiere terminal. Aparece como ícono en la barra del sistema.
+    Compatible con macOS, Windows y Linux.
+
+    \b
+    Para personas con discapacidad: activá 'Iniciar con el sistema'
+    desde el menú del ícono para que Jarvis inicie automáticamente.
+    """
+    try:
+        from jarvis.tray import run_tray
+    except ImportError as e:
+        _fail(f"No se pudo cargar el modo desktop: {e}")
+        click.echo(
+            click.style(
+                "\nInstalá las dependencias de escritorio:\n"
+                "  pip install pystray Pillow\n",
+                fg="yellow",
+            )
+        )
+        sys.exit(1)
+    run_tray()
+
+
 if __name__ == "__main__":
     main()

--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -188,13 +188,28 @@ def _start_pty() -> None:
 
 
 def _start_daemon() -> None:
-    """Inicia el modo Daemon (servidor TCP + hooks)."""
-    try:
-        from core.server import jarvis_daemon
-        jarvis_daemon.main()
-    except ImportError as e:
-        _fail(f"No se pudo cargar el daemon: {e}")
-        sys.exit(1)
+    """
+    Inicia el modo de operación según el backend seleccionado.
+    - claude  → JarvisAPISession (streaming directo, sin PTY)
+    - gemini / groq → daemon TCP con hooks del CLI
+    """
+    backend = os.getenv("ACTIVE_BRAIN_ENGINE", "gemini").lower()
+
+    if backend == "claude":
+        try:
+            from core.session.jarvis_api_session import JarvisAPISession
+            session = JarvisAPISession()
+            session.run()
+        except ImportError as e:
+            _fail(f"No se pudo cargar la sesión Claude API: {e}")
+            sys.exit(1)
+    else:
+        try:
+            from core.server import jarvis_daemon
+            jarvis_daemon.main()
+        except ImportError as e:
+            _fail(f"No se pudo cargar el daemon: {e}")
+            sys.exit(1)
 
 
 # ─── jarvis doctor ────────────────────────────────────────────────────────────

--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -1,0 +1,394 @@
+"""
+J.A.R.V.I.S. CLI — Entry point principal.
+Subcomandos: start, doctor, config
+"""
+from __future__ import annotations
+
+import os
+import sys
+import click
+
+# Asegurar que el root del proyecto esté en el path
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+
+
+# ─── Helpers de output ────────────────────────────────────────────────────────
+
+def _ok(msg: str) -> None:
+    click.echo(click.style(f"  ✓ {msg}", fg="green"))
+
+
+def _warn(msg: str) -> None:
+    click.echo(click.style(f"  ⚠ {msg}", fg="yellow"))
+
+
+def _fail(msg: str) -> None:
+    click.echo(click.style(f"  ✗ {msg}", fg="red"))
+
+
+def _header(msg: str) -> None:
+    click.echo(click.style(f"\n{msg}", bold=True))
+
+
+# ─── Validación de entorno ────────────────────────────────────────────────────
+
+REQUIRED_VARS: dict[str, list[str]] = {
+    "gemini":  ["GEMINI_API_KEY"],
+    "claude":  ["ANTHROPIC_API_KEY"],
+    "groq":    ["GROQ_API_KEY"],
+}
+
+OPTIONAL_VARS = {
+    "OPENROUTER_API_KEY": "OpenRouter (backend alternativo)",
+}
+
+
+def _validate_env(backend: str) -> list[str]:
+    """
+    Valida las variables de entorno necesarias para el backend seleccionado.
+    Retorna lista de errores. Lista vacía = todo OK.
+    """
+    errors: list[str] = []
+    required = REQUIRED_VARS.get(backend, [])
+    for var in required:
+        if not os.getenv(var):
+            errors.append(f"Falta la variable de entorno: {var}")
+    return errors
+
+
+def _load_dotenv() -> None:
+    """Carga .env si existe, silenciosamente."""
+    try:
+        from dotenv import load_dotenv
+        env_path = os.path.join(PROJECT_ROOT, ".env")
+        if os.path.exists(env_path):
+            load_dotenv(env_path)
+    except ImportError:
+        pass
+
+
+# ─── Grupo principal ──────────────────────────────────────────────────────────
+
+@click.group()
+@click.version_option(version="0.1.0", prog_name="jarvis")
+def main() -> None:
+    """
+    J.A.R.V.I.S. — Voice-First Programming CLI.
+
+    \b
+    Comandos principales:
+      jarvis start    Inicia el sistema de voz
+      jarvis doctor   Verifica el estado del sistema
+      jarvis config   Muestra la configuración actual
+    """
+    pass
+
+
+# ─── jarvis start ─────────────────────────────────────────────────────────────
+
+@main.command()
+@click.option(
+    "--backend",
+    type=click.Choice(["gemini", "claude", "groq"], case_sensitive=False),
+    default=None,
+    envvar="ACTIVE_BRAIN_ENGINE",
+    show_envvar=True,
+    help="Motor LLM a utilizar. Sobreescribe ACTIVE_BRAIN_ENGINE del .env.",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["daemon", "pty"], case_sensitive=False),
+    default="daemon",
+    show_default=True,
+    help=(
+        "Modo de operación: "
+        "'daemon' usa el servidor TCP con hooks de Gemini CLI, "
+        "'pty' wrappea el CLI directamente en la terminal actual."
+    ),
+)
+def start(backend: str | None, mode: str) -> None:
+    """Inicia J.A.R.V.I.S. con el backend y modo seleccionados."""
+    _load_dotenv()
+
+    # Determinar backend efectivo
+    effective_backend = (backend or os.getenv("ACTIVE_BRAIN_ENGINE", "gemini")).lower()
+
+    # Validar entorno ANTES de arrancar
+    errors = _validate_env(effective_backend)
+    if errors:
+        click.echo(click.style("\n[J.A.R.V.I.S] Error de configuración:\n", fg="red", bold=True))
+        for err in errors:
+            _fail(err)
+        click.echo(
+            click.style(
+                f"\nEditá el archivo .env y agregá la API key para el backend '{effective_backend}'.\n"
+                f"Podés copiarte el template: cp .env.example .env\n",
+                fg="yellow",
+            )
+        )
+        sys.exit(1)
+
+    # Inyectar backend en el entorno para que los módulos lo lean
+    os.environ["ACTIVE_BRAIN_ENGINE"] = effective_backend
+
+    # Descargar modelos si es la primera vez
+    _ensure_models()
+
+    click.echo(
+        click.style(
+            f"\n[J.A.R.V.I.S] Iniciando — backend: {effective_backend.upper()}, modo: {mode}\n",
+            fg="cyan",
+            bold=True,
+        )
+    )
+
+    if mode == "pty":
+        _start_pty()
+    else:
+        _start_daemon()
+
+
+def _ensure_models() -> None:
+    """
+    Verifica que los modelos de wake word estén descargados.
+    Si no están, los descarga automáticamente (solo ocurre la primera vez).
+    """
+    try:
+        import openwakeword
+        models_path = os.path.join(
+            os.path.dirname(openwakeword.__file__), "resources", "models"
+        )
+        has_models = (
+            os.path.isdir(models_path)
+            and any(f.endswith(".onnx") for f in os.listdir(models_path))
+        )
+        if not has_models:
+            click.echo(
+                click.style(
+                    "\n[J.A.R.V.I.S] Primera ejecución — descargando modelos de wake word...",
+                    fg="yellow",
+                )
+            )
+            from openwakeword.utils import download_models
+            download_models()
+            click.echo(click.style("  ✓ Modelos descargados correctamente.\n", fg="green"))
+    except Exception as e:
+        click.echo(click.style(f"\n  ⚠ No se pudieron descargar los modelos: {e}\n", fg="yellow"))
+
+
+def _start_pty() -> None:
+    """Inicia el modo PTY (wrappea el CLI en la terminal actual)."""
+    try:
+        import main as jarvis_main
+        jarvis_main.main()
+    except ImportError as e:
+        _fail(f"No se pudo cargar el modo PTY: {e}")
+        sys.exit(1)
+
+
+def _start_daemon() -> None:
+    """Inicia el modo Daemon (servidor TCP + hooks)."""
+    try:
+        from core.server import jarvis_daemon
+        jarvis_daemon.main()
+    except ImportError as e:
+        _fail(f"No se pudo cargar el daemon: {e}")
+        sys.exit(1)
+
+
+# ─── jarvis doctor ────────────────────────────────────────────────────────────
+
+@main.command()
+@click.option(
+    "--backend",
+    type=click.Choice(["gemini", "claude", "groq"], case_sensitive=False),
+    default=None,
+    envvar="ACTIVE_BRAIN_ENGINE",
+    help="Backend a verificar (por defecto usa ACTIVE_BRAIN_ENGINE o 'gemini').",
+)
+def doctor(backend: str | None) -> None:
+    """Verifica que el entorno esté correctamente configurado."""
+    _load_dotenv()
+    effective_backend = (backend or os.getenv("ACTIVE_BRAIN_ENGINE", "gemini")).lower()
+
+    click.echo(click.style("\n[J.A.R.V.I.S] Doctor — verificando el sistema...\n", bold=True))
+    all_ok = True
+
+    # ── Python ────────────────────────────────────────────────────────────────
+    _header("Python")
+    major, minor = sys.version_info[:2]
+    if major >= 3 and minor >= 10:
+        _ok(f"Python {major}.{minor} (mínimo requerido: 3.10)")
+    else:
+        _fail(f"Python {major}.{minor} — se requiere 3.10 o superior")
+        all_ok = False
+
+    # ── Variables de entorno ──────────────────────────────────────────────────
+    _header(f"Variables de entorno (backend: {effective_backend.upper()})")
+    env_errors = _validate_env(effective_backend)
+    if env_errors:
+        for err in env_errors:
+            _fail(err)
+        all_ok = False
+    else:
+        required = REQUIRED_VARS.get(effective_backend, [])
+        for var in required:
+            _ok(f"{var} ✓")
+
+    for var, desc in OPTIONAL_VARS.items():
+        if os.getenv(var):
+            _ok(f"{var} ✓ ({desc})")
+        else:
+            _warn(f"{var} no configurado ({desc}) — opcional")
+
+    # ── Dependencias de Python ────────────────────────────────────────────────
+    _header("Dependencias de Python")
+
+    deps_to_check = {
+        "pyaudio":          "Audio I/O",
+        "webrtcvad":        "Voice Activity Detection",
+        "openwakeword":     "Wake word detection",
+        "mlx_whisper":      "STT local (Apple Silicon)",
+        "google.generativeai": "Gemini API",
+        "groq":             "Groq API",
+        "anthropic":        "Claude API",
+        "dotenv":           "python-dotenv",
+        "edge_tts":         "Edge TTS",
+        "click":            "CLI framework",
+    }
+
+    for module, desc in deps_to_check.items():
+        try:
+            import warnings
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                __import__(module)
+            _ok(f"{module} — {desc}")
+        except ImportError:
+            if module in ("anthropic",) and effective_backend != "claude":
+                _warn(f"{module} no instalado — {desc} (no requerido para backend '{effective_backend}')")
+            elif module in ("google.generativeai",) and effective_backend != "gemini":
+                _warn(f"{module} no instalado — {desc} (no requerido para backend '{effective_backend}')")
+            elif module in ("groq",) and effective_backend != "groq":
+                _warn(f"{module} no instalado — {desc} (no requerido para backend '{effective_backend}')")
+            else:
+                _fail(f"{module} no instalado — {desc}")
+                all_ok = False
+
+    # ── Audio ─────────────────────────────────────────────────────────────────
+    _header("Dispositivos de audio")
+    try:
+        import pyaudio
+        pa = pyaudio.PyAudio()
+        device_count = pa.get_device_count()
+        input_devices = [
+            pa.get_device_info_by_index(i)
+            for i in range(device_count)
+            if pa.get_device_info_by_index(i)["maxInputChannels"] > 0
+        ]
+        pa.terminate()
+        if input_devices:
+            _ok(f"{len(input_devices)} dispositivo(s) de entrada detectado(s)")
+            for dev in input_devices[:3]:
+                click.echo(f"     • {dev['name']}")
+        else:
+            _fail("No se detectó ningún micrófono")
+            all_ok = False
+    except Exception as e:
+        _fail(f"Error al verificar audio: {e}")
+        all_ok = False
+
+    # ── Herramientas del sistema ───────────────────────────────────────────────
+    _header("Herramientas del sistema")
+    import shutil
+    tools = {
+        "ffmpeg":  "Reproducción de audio (Edge TTS)",
+        "gemini":  "Gemini CLI (modo PTY/daemon)",
+    }
+    for tool, desc in tools.items():
+        path = shutil.which(tool)
+        if path:
+            _ok(f"{tool} encontrado en {path} — {desc}")
+        else:
+            if tool == "gemini" and effective_backend != "gemini":
+                _warn(f"{tool} no encontrado — {desc} (no requerido para backend '{effective_backend}')")
+            else:
+                _warn(f"{tool} no encontrado — {desc}")
+
+    # ── Modelos locales ───────────────────────────────────────────────────────
+    _header("Modelos locales")
+    _check_wakeword_models()
+
+    # ── Resultado final ───────────────────────────────────────────────────────
+    click.echo()
+    if all_ok:
+        click.echo(click.style("✅  Sistema listo. Podés ejecutar: jarvis start\n", fg="green", bold=True))
+    else:
+        click.echo(
+            click.style(
+                "❌  Hay problemas que resolver. Revisá los errores de arriba.\n"
+                "    Si es la primera vez, ejecutá: bash install.sh\n",
+                fg="red",
+                bold=True,
+            )
+        )
+        sys.exit(1)
+
+
+def _check_wakeword_models() -> None:
+    """Verifica que los modelos de wake word estén descargados."""
+    models_dir = os.path.expanduser("~/.jarvis/models")
+    openwakeword_cache = os.path.join(
+        os.path.expanduser("~"),
+        "Library", "Caches", "openwakeword"
+    )
+
+    found_any = False
+    for search_path in [models_dir, openwakeword_cache]:
+        if os.path.isdir(search_path):
+            model_files = [f for f in os.listdir(search_path) if f.endswith((".onnx", ".tflite"))]
+            if model_files:
+                _ok(f"Modelos wake word encontrados en {search_path} ({len(model_files)} archivos)")
+                found_any = True
+                break
+
+    if not found_any:
+        _warn("Modelos de wake word no encontrados — ejecutá: python download_models.py")
+
+
+# ─── jarvis config ────────────────────────────────────────────────────────────
+
+@main.command("config")
+def show_config() -> None:
+    """Muestra la configuración activa del sistema."""
+    _load_dotenv()
+
+    click.echo(click.style("\n[J.A.R.V.I.S] Configuración activa\n", bold=True))
+
+    settings = {
+        "Backend LLM":    os.getenv("ACTIVE_BRAIN_ENGINE", "gemini (default)"),
+        "Motor TTS":      os.getenv("ACTIVE_TTS_ENGINE",   "mac_say (default)"),
+        "Motor STT":      os.getenv("ACTIVE_STT_ENGINE",   "mlx_whisper (default)"),
+        "Gemini API Key": "✓ configurada" if os.getenv("GEMINI_API_KEY") else "✗ no configurada",
+        "Anthropic API":  "✓ configurada" if os.getenv("ANTHROPIC_API_KEY") else "✗ no configurada",
+        "Groq API Key":   "✓ configurada" if os.getenv("GROQ_API_KEY") else "✗ no configurada",
+        "Proyecto .env":  os.path.join(PROJECT_ROOT, ".env"),
+    }
+
+    max_len = max(len(k) for k in settings)
+    for key, value in settings.items():
+        color = "green" if "✓" in str(value) else ("red" if "✗" in str(value) else "white")
+        click.echo(f"  {key:<{max_len}}  {click.style(str(value), fg=color)}")
+
+    click.echo()
+    click.echo(
+        click.style(
+            "Para cambiar la configuración, editá el archivo .env del proyecto.\n",
+            fg="yellow",
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -107,7 +107,19 @@ def main() -> None:
         "'pty' wrappea el CLI directamente en la terminal actual."
     ),
 )
-def start(backend: str | None, mode: str) -> None:
+@click.option(
+    "--cli",
+    "cli_tool",
+    type=click.Choice(["gemini", "claude-code"], case_sensitive=False),
+    default="gemini",
+    show_default=True,
+    help=(
+        "CLI a wrappear en modo PTY. "
+        "'gemini' usa Gemini CLI, "
+        "'claude-code' usa Claude Code CLI (`claude`)."
+    ),
+)
+def start(backend: str | None, mode: str, cli_tool: str) -> None:
     """Inicia J.A.R.V.I.S. con el backend y modo seleccionados."""
     _load_dotenv()
 
@@ -148,16 +160,17 @@ def start(backend: str | None, mode: str) -> None:
     # Descargar modelos si es la primera vez
     _ensure_models()
 
+    cli_label = f", cli: {cli_tool}" if mode == "pty" else ""
     click.echo(
         click.style(
-            f"\n[J.A.R.V.I.S] Iniciando — backend: {effective_backend.upper()}, modo: {mode}\n",
+            f"\n[J.A.R.V.I.S] Iniciando — backend: {effective_backend.upper()}, modo: {mode}{cli_label}\n",
             fg="cyan",
             bold=True,
         )
     )
 
     if mode == "pty":
-        _start_pty()
+        _start_pty(cli_tool)
     else:
         _start_daemon()
 
@@ -215,14 +228,30 @@ def _ensure_models() -> None:
         click.echo(click.style(f"\n  ⚠ No se pudieron descargar los modelos: {e}\n", fg="yellow"))
 
 
-def _start_pty() -> None:
-    """Inicia el modo PTY (wrappea el CLI en la terminal actual)."""
-    try:
-        import main as jarvis_main
-        jarvis_main.main()
-    except ImportError as e:
-        _fail(f"No se pudo cargar el modo PTY: {e}")
-        sys.exit(1)
+def _start_pty(cli_tool: str = "gemini") -> None:
+    """
+    Inicia el modo PTY.
+    - 'gemini'      → main.py (Gemini CLI wrapper original)
+    - 'claude-code' → ClaudeCodePtySession (Claude Code CLI wrapper)
+    """
+    if cli_tool == "claude-code":
+        try:
+            import shutil
+            if not shutil.which("claude"):
+                _fail("Claude Code CLI no encontrado. Instalalo con: npm install -g @anthropic-ai/claude-code")
+                sys.exit(1)
+            from core.session.claude_code_pty_session import ClaudeCodePtySession
+            ClaudeCodePtySession().run()
+        except ImportError as e:
+            _fail(f"No se pudo cargar la sesión Claude Code PTY: {e}")
+            sys.exit(1)
+    else:
+        try:
+            import main as jarvis_main
+            jarvis_main.main()
+        except ImportError as e:
+            _fail(f"No se pudo cargar el modo PTY (Gemini): {e}")
+            sys.exit(1)
 
 
 def _start_daemon() -> None:

--- a/jarvis/tray.py
+++ b/jarvis/tray.py
@@ -1,0 +1,357 @@
+"""
+J.A.R.V.I.S. — System Tray Desktop App.
+
+Cross-platform entry point for accessibility. No terminal required.
+Users interact through the system tray icon: click to start/stop voice.
+
+Supported platforms: macOS, Windows, Linux (requires libayatana-appindicator on GNOME).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+
+logger = logging.getLogger(__name__)
+
+# Ensure project root is on path when running as a bundled .app / .exe
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+
+def _require(package: str, install_hint: str) -> None:
+    try:
+        __import__(package)
+    except ImportError:
+        print(
+            f"[J.A.R.V.I.S] Falta dependencia: {package}\n"
+            f"  Instalá con: {install_hint}"
+        )
+        sys.exit(1)
+
+
+_require("pystray", "pip install pystray")
+_require("PIL", "pip install Pillow")
+
+import pystray  # noqa: E402
+from PIL import Image, ImageDraw  # noqa: E402
+
+
+# ── Icon generation ────────────────────────────────────────────────────────────
+
+def _make_icon(active: bool = False) -> Image.Image:
+    """Generate tray icon in memory. Blue = idle, green = listening."""
+    size = 64
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    # Background circle
+    fill = (0, 200, 80, 255) if active else (0, 120, 220, 255)
+    draw.ellipse((2, 2, size - 2, size - 2), fill=fill)
+
+    # Microphone body (rect)
+    draw.rounded_rectangle((22, 12, 42, 36), radius=8, fill=(255, 255, 255, 230))
+
+    # Microphone stand (arc + line)
+    draw.arc((16, 26, 48, 46), start=0, end=180, fill=(255, 255, 255, 230), width=3)
+    draw.line((32, 46, 32, 54), fill=(255, 255, 255, 230), width=3)
+    draw.line((24, 54, 40, 54), fill=(255, 255, 255, 230), width=3)
+
+    # Green activity dot when active
+    if active:
+        draw.ellipse((44, 44, 58, 58), fill=(255, 255, 100, 255))
+
+    return img
+
+
+def _load_icon_file(active: bool = False) -> Image.Image:
+    """Try to load a pre-generated icon file, fall back to generated icon."""
+    assets_dir = os.path.join(_HERE, "assets")
+    name = "icon_active.png" if active else "icon.png"
+    path = os.path.join(assets_dir, name)
+    if os.path.exists(path):
+        try:
+            return Image.open(path)
+        except Exception:
+            pass
+    return _make_icon(active)
+
+
+# ── Auto-start helpers ─────────────────────────────────────────────────────────
+
+def _autostart_file() -> str | None:
+    """Path to the auto-start config file for the current platform (None = registry on Win)."""
+    if sys.platform == "darwin":
+        return os.path.expanduser("~/Library/LaunchAgents/com.jarvis.voice.plist")
+    if sys.platform == "win32":
+        return None  # Uses Windows registry
+    return os.path.expanduser("~/.config/autostart/jarvis.desktop")
+
+
+def _is_autostart_enabled() -> bool:
+    path = _autostart_file()
+    if path:
+        return os.path.exists(path)
+    if sys.platform == "win32":
+        try:
+            import winreg  # type: ignore[import]
+            key = winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Run",
+                0,
+                winreg.KEY_READ,
+            )
+            winreg.QueryValueEx(key, "JARVIS")
+            winreg.CloseKey(key)
+            return True
+        except OSError:
+            return False
+    return False
+
+
+def _enable_autostart() -> None:
+    exe = sys.executable
+    path = _autostart_file()
+
+    if sys.platform == "darwin":
+        plist = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.jarvis.voice</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{exe}</string>
+        <string>-m</string>
+        <string>jarvis.tray</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><false/>
+    <key>StandardOutPath</key>
+    <string>{os.path.expanduser("~/Library/Logs/jarvis.log")}</string>
+    <key>StandardErrorPath</key>
+    <string>{os.path.expanduser("~/Library/Logs/jarvis-error.log")}</string>
+</dict>
+</plist>"""
+        assert path is not None
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(plist)
+        import subprocess
+        subprocess.run(["launchctl", "load", path], capture_output=True)
+
+    elif sys.platform == "win32":
+        import winreg  # type: ignore[import]
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Run",
+            0,
+            winreg.KEY_SET_VALUE,
+        )
+        winreg.SetValueEx(key, "JARVIS", 0, winreg.REG_SZ, f'"{exe}" -m jarvis.tray')
+        winreg.CloseKey(key)
+
+    else:  # Linux
+        desktop = (
+            "[Desktop Entry]\n"
+            "Type=Application\n"
+            "Name=J.A.R.V.I.S\n"
+            f"Exec={exe} -m jarvis.tray\n"
+            "Icon=microphone\n"
+            "Hidden=false\n"
+            "NoDisplay=false\n"
+            "X-GNOME-Autostart-enabled=true\n"
+        )
+        assert path is not None
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(desktop)
+
+
+def _disable_autostart() -> None:
+    path = _autostart_file()
+
+    if sys.platform == "darwin" and path and os.path.exists(path):
+        import subprocess
+        subprocess.run(["launchctl", "unload", path], capture_output=True)
+        os.remove(path)
+
+    elif sys.platform == "win32":
+        try:
+            import winreg  # type: ignore[import]
+            key = winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Run",
+                0,
+                winreg.KEY_SET_VALUE,
+            )
+            winreg.DeleteValue(key, "JARVIS")
+            winreg.CloseKey(key)
+        except OSError:
+            pass
+
+    elif path and os.path.exists(path):
+        os.remove(path)
+
+
+# ── Session controller ─────────────────────────────────────────────────────────
+
+class _TrayController:
+    """Manages the Jarvis voice session lifecycle from the system tray."""
+
+    def __init__(self) -> None:
+        self._session = None
+        self._thread: threading.Thread | None = None
+        self._running = False
+        self._icon: pystray.Icon | None = None
+
+    # ── Notification ──────────────────────────────────────────────────────────
+
+    def _notify(self, message: str) -> None:
+        if self._icon:
+            try:
+                self._icon.notify(message, "J.A.R.V.I.S")
+            except Exception:
+                pass
+
+    # ── Voice session ─────────────────────────────────────────────────────────
+
+    def start_voice(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        if self._running:
+            self._notify("J.A.R.V.I.S ya está activo")
+            return
+
+        self._running = True
+        icon.icon = _load_icon_file(active=True)
+        self._notify("Iniciando… Decí 'Hey Jarvis' para comenzar")
+
+        def _run() -> None:
+            try:
+                from jarvis.cli import _load_dotenv
+                _load_dotenv()
+                backend = os.getenv("ACTIVE_BRAIN_ENGINE", "gemini").lower()
+                if backend == "claude":
+                    from core.session.jarvis_api_session import JarvisAPISession
+                    self._session = JarvisAPISession()
+                    self._session.run()
+                else:
+                    from core.server import jarvis_daemon
+                    jarvis_daemon.main()
+            except Exception as exc:
+                logger.error("[Tray] Error en sesión: %s", exc)
+                self._notify(f"Error: {exc}")
+            finally:
+                self._running = False
+                self._session = None
+                if icon:
+                    icon.icon = _load_icon_file(active=False)
+                    icon.update_menu()
+
+        self._thread = threading.Thread(target=_run, daemon=True, name="jarvis-session")
+        self._thread.start()
+        icon.update_menu()
+
+    def stop_voice(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        if not self._running:
+            self._notify("J.A.R.V.I.S no está activo")
+            return
+        if self._session and hasattr(self._session, "stop"):
+            self._session.stop()
+        self._running = False
+        self._notify("J.A.R.V.I.S detenido")
+        icon.icon = _load_icon_file(active=False)
+        icon.update_menu()
+
+    # ── Auto-start toggle ─────────────────────────────────────────────────────
+
+    def toggle_autostart(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        if _is_autostart_enabled():
+            _disable_autostart()
+            self._notify("Auto-inicio desactivado")
+        else:
+            _enable_autostart()
+            self._notify("J.A.R.V.I.S iniciará automáticamente con el sistema")
+        icon.update_menu()
+
+    # ── Config ────────────────────────────────────────────────────────────────
+
+    def open_config(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        import subprocess
+        env_path = os.path.join(_ROOT, ".env")
+        if not os.path.exists(env_path):
+            example = os.path.join(_ROOT, ".env.example")
+            if os.path.exists(example):
+                import shutil
+                shutil.copy(example, env_path)
+        if sys.platform == "darwin":
+            subprocess.run(["open", env_path])
+        elif sys.platform == "win32":
+            os.startfile(env_path)  # type: ignore[attr-defined]
+        else:
+            subprocess.run(["xdg-open", env_path])
+
+    # ── Quit ──────────────────────────────────────────────────────────────────
+
+    def quit(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        self._running = False
+        if self._session and hasattr(self._session, "stop"):
+            self._session.stop()
+        icon.stop()
+
+    # ── Menu ──────────────────────────────────────────────────────────────────
+
+    def build_menu(self) -> pystray.Menu:
+        return pystray.Menu(
+            pystray.MenuItem(
+                "▶  Activar voz",
+                self.start_voice,
+                default=True,
+                enabled=lambda _: not self._running,
+            ),
+            pystray.MenuItem(
+                "⏹  Detener voz",
+                self.stop_voice,
+                enabled=lambda _: self._running,
+            ),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem(
+                "Iniciar con el sistema",
+                self.toggle_autostart,
+                checked=lambda _: _is_autostart_enabled(),
+            ),
+            pystray.MenuItem("⚙  Configuración (.env)", self.open_config),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("✕  Salir", self.quit),
+        )
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def run_tray() -> None:
+    """Launch J.A.R.V.I.S as a system tray application. No terminal needed."""
+    # Load .env before anything so ACTIVE_BRAIN_ENGINE is available at startup
+    try:
+        from dotenv import load_dotenv
+        env_path = os.path.join(_ROOT, ".env")
+        if os.path.exists(env_path):
+            load_dotenv(env_path)
+    except ImportError:
+        pass
+
+    ctrl = _TrayController()
+    icon = pystray.Icon(
+        name="jarvis",
+        icon=_load_icon_file(active=False),
+        title="J.A.R.V.I.S — Voice Assistant",
+        menu=ctrl.build_menu(),
+    )
+    ctrl._icon = icon
+    icon.run()
+
+
+if __name__ == "__main__":
+    run_tray()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "edge-tts>=7.2.7",
     "openwakeword",
     "mlx-whisper",
+    "pynput",
     "setuptools",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,30 @@ dependencies = [
     "python-dotenv",
     "edge-tts>=7.2.7",
     "openwakeword",
-    "mlx-whisper",
     "pynput",
     "setuptools",
 ]
 
+[project.optional-dependencies]
+# Apple Silicon STT (Mac M1/M2/M3/M4 only)
+mac-stt = ["mlx-whisper"]
+
+# Cross-platform STT (Windows, Linux, Intel Mac)
+stt = ["faster-whisper"]
+
+# Desktop tray app (all platforms)
+desktop = ["pystray", "Pillow>=10.0"]
+
+# Full install: everything needed to run on any platform
+all = [
+    "faster-whisper",
+    "pystray",
+    "Pillow>=10.0",
+]
+
 [project.scripts]
 jarvis = "jarvis.cli:main"
+jarvis-desktop = "jarvis.tray:run_tray"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jarvis-voice-cli"
+version = "0.1.0"
+description = "J.A.R.V.I.S. — Voice-First Programming CLI"
+requires-python = ">=3.10"
+dependencies = [
+    "click>=8.1",
+    "pyaudio",
+    "webrtcvad",
+    "numpy",
+    "google-generativeai",
+    "groq",
+    "openai",
+    "python-dotenv",
+    "edge-tts>=7.2.7",
+    "openwakeword",
+    "mlx-whisper",
+    "setuptools",
+]
+
+[project.scripts]
+jarvis = "jarvis.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["jarvis*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+anthropic>=0.40.0
 click>=8.1
 pyaudio
 webrtcvad

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click>=8.1
 pyaudio
 webrtcvad
 setuptools

--- a/scripts/generate_icon.py
+++ b/scripts/generate_icon.py
@@ -1,0 +1,131 @@
+"""
+Generate icon assets for J.A.R.V.I.S desktop app.
+
+Run this script once before building with PyInstaller:
+    python scripts/generate_icon.py
+
+Outputs:
+    jarvis/assets/icon.png        — 512x512 PNG (Linux tray + source)
+    jarvis/assets/icon_active.png — 512x512 PNG (green, listening state)
+    jarvis/assets/icon.ico        — Windows multi-size .ico
+    jarvis/assets/icon.icns       — macOS .icns (requires Pillow + macOS)
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+try:
+    from PIL import Image, ImageDraw
+except ImportError:
+    print("Instalá Pillow primero: pip install Pillow")
+    sys.exit(1)
+
+ASSETS_DIR = os.path.join(os.path.dirname(__file__), "..", "jarvis", "assets")
+os.makedirs(ASSETS_DIR, exist_ok=True)
+
+
+def _draw_icon(size: int = 512, active: bool = False) -> Image.Image:
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    pad = int(size * 0.04)
+    circle_fill = (0, 200, 80, 255) if active else (0, 120, 220, 255)
+    draw.ellipse((pad, pad, size - pad, size - pad), fill=circle_fill)
+
+    # Microphone body
+    mx1 = int(size * 0.34)
+    mx2 = int(size * 0.66)
+    my1 = int(size * 0.16)
+    my2 = int(size * 0.56)
+    radius = int(size * 0.13)
+    draw.rounded_rectangle((mx1, my1, mx2, my2), radius=radius, fill=(255, 255, 255, 230))
+
+    # Microphone arc (stand)
+    arc_pad = int(size * 0.24)
+    arc_top = int(size * 0.40)
+    arc_bot = int(size * 0.70)
+    stroke = max(3, int(size * 0.04))
+    draw.arc((arc_pad, arc_top, size - arc_pad, arc_bot), start=0, end=180,
+             fill=(255, 255, 255, 230), width=stroke)
+
+    # Stand line + base
+    cx = size // 2
+    line_top = int(size * 0.70)
+    line_bot = int(size * 0.82)
+    base_w = int(size * 0.24)
+    draw.line((cx, line_top, cx, line_bot), fill=(255, 255, 255, 230), width=stroke)
+    draw.line((cx - base_w // 2, line_bot, cx + base_w // 2, line_bot),
+              fill=(255, 255, 255, 230), width=stroke)
+
+    # Activity dot when active
+    if active:
+        dot = int(size * 0.10)
+        dot_x = int(size * 0.68)
+        dot_y = int(size * 0.68)
+        draw.ellipse((dot_x, dot_y, dot_x + dot, dot_y + dot), fill=(255, 220, 50, 255))
+
+    return img
+
+
+def _save_png(img: Image.Image, name: str) -> None:
+    path = os.path.join(ASSETS_DIR, name)
+    img.save(path, format="PNG")
+    print(f"  ✓ {path}")
+
+
+def _save_ico(img: Image.Image) -> None:
+    path = os.path.join(ASSETS_DIR, "icon.ico")
+    sizes = [16, 32, 48, 64, 128, 256]
+    imgs = [img.resize((s, s), Image.LANCZOS) for s in sizes]
+    imgs[0].save(path, format="ICO", sizes=[(s, s) for s in sizes], append_images=imgs[1:])
+    print(f"  ✓ {path}")
+
+
+def _save_icns(img: Image.Image) -> None:
+    """Save .icns using macOS iconutil (macOS only)."""
+    import subprocess
+    import tempfile
+    import shutil
+
+    if sys.platform != "darwin":
+        print("  ⚠ .icns solo se puede generar en macOS. Saltando.")
+        return
+    if not shutil.which("iconutil"):
+        print("  ⚠ iconutil no encontrado. Saltando .icns.")
+        return
+
+    sizes = [16, 32, 64, 128, 256, 512, 1024]
+    with tempfile.TemporaryDirectory(suffix=".iconset") as iconset:
+        for s in sizes:
+            resized = img.resize((s, s), Image.LANCZOS)
+            resized.save(os.path.join(iconset, f"icon_{s}x{s}.png"))
+            # Retina
+            retina = img.resize((s * 2, s * 2), Image.LANCZOS)
+            retina.save(os.path.join(iconset, f"icon_{s}x{s}@2x.png"))
+
+        out_path = os.path.join(ASSETS_DIR, "icon.icns")
+        result = subprocess.run(["iconutil", "-c", "icns", iconset, "-o", out_path],
+                                capture_output=True)
+        if result.returncode == 0:
+            print(f"  ✓ {out_path}")
+        else:
+            print(f"  ✗ Error generando .icns: {result.stderr.decode()}")
+
+
+def main() -> None:
+    print("Generando íconos de J.A.R.V.I.S...")
+
+    base = _draw_icon(size=512, active=False)
+    active = _draw_icon(size=512, active=True)
+
+    _save_png(base, "icon.png")
+    _save_png(active, "icon_active.png")
+    _save_ico(base)
+    _save_icns(base)
+
+    print("\n¡Listo! Íconos generados en jarvis/assets/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #2

## Tipo de cambio
- [x] New feature

## Resumen
- Agrega `ClaudeAPIAdapter` que conecta directamente con la API de Anthropic vía streaming — sin proceso PTY, sin CLI externo
- Agrega `JarvisAPISession` que orquesta el flujo completo: Wake word → Whisper STT → Claude API → Lexer → TTS
- `jarvis start --backend claude` usa este nuevo flujo en lugar del daemon TCP

## Cambios

| Archivo | Cambio |
|---------|--------|
| `adapters/llm/claude_api_adapter.py` | Nuevo adapter con streaming y multi-turn history |
| `core/session/jarvis_api_session.py` | Sesión completa para modo API |
| `core/session/__init__.py` | Nuevo package |
| `core/audio/vad_listener.py` | Agrega `on_transcription` callback (backward-compatible) |
| `jarvis/cli.py` | Rutea `--backend claude` a `JarvisAPISession` |
| `requirements.txt` | Agrega `anthropic>=0.40.0` |

## Plan de prueba
- [x] `ClaudeAPIAdapter`, `JarvisAPISession` y `start_vad_thread` importan sin errores
- [x] `jarvis start --backend claude` sin API key falla con mensaje claro (exit 1)
- [x] `vad_listener` existente funciona igual (parámetro `on_transcription=None` por defecto)
- [ ] Test de streaming real (requiere `ANTHROPIC_API_KEY` en `.env`)